### PR TITLE
Update travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,11 @@ script:
   - |
     if [ "${TRAVIS_BRANCH}" == "master" ]; then
       export DOCKER_IMAGE_TAG=master
+    else if [ -n "${TRAVIS_TAG}" ]; then
+      # use a release version as a docker image tag
+      export RELEASE_VER=${TRAVIS_TAG}
     else
-      export DOCKER_IMAGE_TAG=`git rev-parse --short HEAD`
+      export RELEASE_VER=`git rev-parse --short HEAD`
     fi
     make all &&
     if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then


### PR DESCRIPTION
Set RELEASE_VER instead of the DOCKER_IMAGE_TAG for travis builds.
Also, use tag names for releases instead of git sha.

Signed-off-by: Serhii Aheienko <serhii.aheienko@gmail.com>