### PR TITLE
Add the ca-certificates package to docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 FROM ubuntu:latest
 MAINTAINER Portworx Inc. <support@portworx.com>
 
+RUN apt-get update \
+    && apt-get dist-upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && apt-get clean -y \
+    && apt-get autoremove -y \
+    && rm -rf /tmp/* /var/tmp/* \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /
 
 COPY ./bin/kdmp /

--- a/Dockerfile.resticexecutor
+++ b/Dockerfile.resticexecutor
@@ -3,6 +3,15 @@ FROM restic/restic:latest AS restic
 FROM ubuntu
 MAINTAINER Portworx Inc. <support@portworx.com>
 
+RUN apt-get update \
+    && apt-get dist-upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && apt-get clean -y \
+    && apt-get autoremove -y \
+    && rm -rf /tmp/* /var/tmp/* \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /
 
 COPY --from=restic /usr/bin/restic /usr/bin


### PR DESCRIPTION
Signed-off-by: Serhii Aheienko <serhii.aheienko@gmail.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
kdmp is failing to deal with secure repositories for backuplocations. Add the ca-certificate package to docker images to fix this.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

