### PR TITLE
PB-1866: Adding support for setting global policy setting

### DIFF
--- a/pkg/kopia/command.go
+++ b/pkg/kopia/command.go
@@ -136,3 +136,23 @@ func (c *Command) ConnectCmd() *exec.Cmd {
 
 	return cmd
 }
+
+// SetPolicyCmd returns os/exec.Cmd object for the kopia policy Command
+func (c *Command) SetPolicyCmd() *exec.Cmd {
+	// Get all the flags
+	argsSlice := []string{
+		"policy",
+		c.Name, // set command
+		"--global",
+	}
+	argsSlice = append(argsSlice, c.Flags...)
+	// Get the cmd args
+	argsSlice = append(argsSlice, c.Args...)
+	cmd := exec.Command(baseCmd, argsSlice...)
+	if len(c.Env) > 0 {
+		cmd.Env = append(os.Environ(), c.Env...)
+	}
+	cmd.Dir = c.Dir
+
+	return cmd
+}

--- a/pkg/kopia/global_policy.go
+++ b/pkg/kopia/global_policy.go
@@ -1,0 +1,74 @@
+package kopia
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+
+	cmdexec "github.com/portworx/kdmp/pkg/executor"
+	"github.com/sirupsen/logrus"
+)
+
+type globalPolicyExecutor struct {
+	cmd       *Command
+	execCmd   *exec.Cmd
+	outBuf    *bytes.Buffer
+	errBuf    *bytes.Buffer
+	lastError error
+}
+
+// SetGlobalPolicyCommand returns a wrapper over the kopia set policy command
+func SetGlobalPolicyCommand() (*Command, error) {
+	return &Command{
+		Name: "set",
+	}, nil
+}
+
+// NewSetGlobalPolicyExecutor returns an instance of Executor that can be used for
+// running a kopia policy command command
+func NewSetGlobalPolicyExecutor(cmd *Command) Executor {
+	return &globalPolicyExecutor{
+		cmd:    cmd,
+		outBuf: new(bytes.Buffer),
+		errBuf: new(bytes.Buffer),
+	}
+}
+
+func (b *globalPolicyExecutor) Run() error {
+	b.execCmd = b.cmd.SetPolicyCmd()
+	b.execCmd.Stdout = b.outBuf
+	b.execCmd.Stderr = b.errBuf
+
+	if err := b.execCmd.Start(); err != nil {
+		b.lastError = err
+		return err
+	}
+
+	go func() {
+		err := b.execCmd.Wait()
+		if err != nil {
+			b.lastError = fmt.Errorf("failed to run the kopia policy command: %v", err)
+			logrus.Errorf("stdout: %v", b.execCmd.Stdout)
+			logrus.Errorf("stderr: %v", b.execCmd.Stderr)
+			return
+		}
+	}()
+
+	return nil
+}
+
+func (b *globalPolicyExecutor) Status() (*cmdexec.Status, error) {
+	if b.lastError != nil {
+		fmt.Fprintln(os.Stderr, b.errBuf.String())
+		return &cmdexec.Status{
+			LastKnownError: b.lastError,
+			Done:           true,
+		}, nil
+	}
+
+	return &cmdexec.Status{
+		Done:           true,
+		LastKnownError: nil,
+	}, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- As part of repository creation during backup, global policy is set to a higher value
  to avoid kopia cleaning snapshots as part of maintenance activity

**Which issue(s) this PR fixes** (optional)
PB-1866

**Special notes for your reviewer**:

Manual notes
1.  Trigger a backup using DataExport CR
2. Connect to the repo 
```
 kopia repository create s3 --bucket=dipti-kopia --access-key=CT6R80D3ST0VW9NY6HYP --secret-access-key=a0V6dPqu8C26KbAsa9qsIrfhsbvyGjjPPmZN2qD4 --endpoint=minio.portworx.dev --prefix=pvc1/
```

3. Now list the global policy for the above repo
```
[root@prashanth-iron-seer-0 helm]# kopia policy show --global
Policy for (global):

Retention:
  Annual snapshots:  9999999           (defined for this target)
  Monthly snapshots: 9999999           (defined for this target)
  Weekly snapshots:  9999999           (defined for this target)
  Daily snapshots:   9999999           (defined for this target)
  Hourly snapshots:  9999999           (defined for this target)
  Latest snapshots:  9999999           (defined for this target)

Files policy:
  Ignore cache directories:        true       (default)
  No ignore rules.
  Read ignore rules from files:
    .kopiaignore                   (defined for this target)
  Scan one filesystem only:       false       (default)

Error handling policy:
  Ignore file read errors:       false       (defined for this target)
  Ignore directory read errors:  false       (defined for this target)
  Ignore unknown types:           true       (defined for this target)

Scheduling policy:
  Scheduled snapshots:
    None
  Manual snapshot:           false   (default)

Compression disabled.

No actions defined.
```