### PR TITLE
pb-1859: Added changes for kopia snapshot delete functionality.

### DIFF
--- a/cmd/exporter/handler/operator/installmanifests_generated.go
+++ b/cmd/exporter/handler/operator/installmanifests_generated.go
@@ -11,12 +11,7 @@ import (
 )
 
 var (
-	operatorServiceAccountYaml = `---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kdmp-operator
-  namespace: kube-system`
+	operatorServiceAccountYaml = ``
 
 	operatorDeploymentYaml = `---
 apiVersion: apps/v1
@@ -55,99 +50,9 @@ spec:
       serviceAccountName: kdmp-operator
 `
 
-	operatorClusterRoleYaml = `---
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-   name: kdmp-operator
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - persistentvolumeclaims
-      - configmaps
-      - events
-      - secrets
-      - serviceaccounts
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - persistentvolumes
-      - pods
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - roles
-      - rolebindings
-    verbs:
-      - '*'
-  - apiGroups:
-      - batch
-    resources:
-      - jobs
-    verbs:
-      - '*'
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - create
-  - apiGroups:
-      - kdmp.portworx.com
-    resources:
-      - dataexports
-      - volumebackups
-    verbs:
-      - '*'
-  - apiGroups:
-      - stork.libopenstorage.org
-    resources:
-      - backuplocations
-    verbs:
-      - '*'
-  - apiGroups:
-      - volumesnapshot.external-storage.k8s.io
-    resources:
-      - volumesnapshotdatas
-      - volumesnapshots
-    verbs:
-      - '*'
-  - apiGroups:
-      - snapshot.storage.k8s.io
-    resources:
-      - volumesnapshotclasses
-      - volumesnapshotcontents
-      - volumesnapshots
-    verbs:
-      - '*'
-  - apiGroups:
-      - security.openshift.io
-    resources:
-      - securitycontextconstraints
-    verbs:
-      - use`
+	operatorClusterRoleYaml = ``
 
-	operatorClusterRoleBindingYaml = `---
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kdmp-operator
-subjects:
-  - kind: ServiceAccount
-    name: kdmp-operator
-    namespace: kube-system
-roleRef:
-  kind: ClusterRole
-  name: kdmp-operator
-  apiGroup: rbac.authorization.k8s.io`
+	operatorClusterRoleBindingYaml = ``
 )
 
 type Manifests struct {

--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -9,6 +9,7 @@ const (
 	ResticRestore = "resticrestore"
 	KopiaBackup   = "kopiabackup"
 	KopiaRestore  = "kopiarestore"
+	KopiaDelete   = "kopiadelete"
 )
 
 // Docker images.

--- a/pkg/drivers/driversinstance/driversinstance.go
+++ b/pkg/drivers/driversinstance/driversinstance.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/portworx/kdmp/pkg/drivers"
 	"github.com/portworx/kdmp/pkg/drivers/kopiabackup"
+	"github.com/portworx/kdmp/pkg/drivers/kopiadelete"
 	"github.com/portworx/kdmp/pkg/drivers/kopiarestore"
 	"github.com/portworx/kdmp/pkg/drivers/resticbackup"
 	"github.com/portworx/kdmp/pkg/drivers/resticrestore"
@@ -20,6 +21,7 @@ var (
 		drivers.ResticRestore: resticrestore.Driver{},
 		drivers.KopiaBackup:   kopiabackup.Driver{},
 		drivers.KopiaRestore:  kopiarestore.Driver{},
+		drivers.KopiaDelete:   kopiadelete.Driver{},
 	}
 )
 

--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -1,0 +1,233 @@
+package kopiadelete
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/portworx/kdmp/pkg/drivers"
+	"github.com/portworx/kdmp/pkg/drivers/utils"
+	"github.com/portworx/sched-ops/k8s/batch"
+	"github.com/sirupsen/logrus"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	kopiaDeleteJobPrefix = "snapshot-delete"
+)
+
+// Driver is a kopia delete snapshot implementation
+type Driver struct{}
+
+// Name returns a name of the driver.
+func (d Driver) Name() string {
+	return drivers.KopiaDelete
+}
+
+// StartJob creates a job for kopia snapshot delete
+func (d Driver) StartJob(opts ...drivers.JobOption) (id string, err error) {
+	fn := "StartJob:"
+	o := drivers.JobOpts{}
+	for _, opt := range opts {
+		if opt != nil {
+			if err := opt(&o); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	if err := d.validate(o); err != nil {
+		errMsg := fmt.Sprintf("validation failed for snapshot delete job for snapshotID [%v]: %v", o.SnapshotID, err)
+		logrus.Infof("%s %v", fn, errMsg)
+		return "", fmt.Errorf(errMsg)
+	}
+	jobName := toJobName(o.SnapshotID)
+	job, err := buildJob(jobName, o)
+	if err != nil {
+		errMsg := fmt.Sprintf("building backup snapshot delete job [%s] failed: %v", jobName, err)
+		logrus.Errorf("%s %v", fn, errMsg)
+		return "", fmt.Errorf(errMsg)
+	}
+	if _, err = batch.Instance().CreateJob(job); err != nil && !apierrors.IsAlreadyExists(err) {
+		errMsg := fmt.Sprintf("creation of backup snapshot delete job [%s] failed: %v", jobName, err)
+		logrus.Errorf("%s %v", fn, errMsg)
+		return "", fmt.Errorf(errMsg)
+	}
+	logrus.Infof("%s created backup snapshot delete job [%s] successfully", fn, job.Name)
+	return utils.NamespacedName(job.Namespace, job.Name), nil
+}
+
+// DeleteJob delete the backup snapshot delete job.
+func (d Driver) DeleteJob(id string) error {
+	fn := "DeleteJob:"
+	namespace, name, err := utils.ParseJobID(id)
+	if err != nil {
+		logrus.Errorf("%s %v", fn, err)
+		return err
+	}
+
+	if err = batch.Instance().DeleteJob(name, namespace); err != nil && !apierrors.IsNotFound(err) {
+		errMsg := fmt.Sprintf("deletion of delete snapshot job [%s/%s] failed: %v", namespace, name, err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		return fmt.Errorf(errMsg)
+	}
+
+	return nil
+}
+
+// JobStatus returns a progress status for a data transfer.
+func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
+	fn := "JobStatus"
+	namespace, name, err := utils.ParseJobID(id)
+	if err != nil {
+		return utils.ToJobStatus(0, err.Error()), nil
+	}
+
+	job, err := batch.Instance().GetJob(name, namespace)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to fetch backup %s/%s job: %v", namespace, name, err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+	if utils.IsJobFailed(job) {
+		errMsg := fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
+		return utils.ToJobStatus(0, errMsg), nil
+	}
+	if utils.IsJobCompleted(job) {
+		return utils.ToJobStatus(drivers.TransferProgressCompleted, ""), nil
+	}
+	return utils.ToJobStatus(0, ""), nil
+}
+
+func (d Driver) validate(o drivers.JobOpts) error {
+	if o.SnapshotID == "" {
+		return fmt.Errorf("snapshotID should be set")
+	}
+	if o.CredSecretName == "" {
+		return fmt.Errorf("credential secret name should be set")
+	}
+	if o.CredSecretNamespace == "" {
+		return fmt.Errorf("credential secret namespace  should be set")
+	}
+	if o.Namespace == "" {
+		return fmt.Errorf("namespace should be set")
+	}
+	if o.SourcePVCName == "" {
+		return fmt.Errorf("sourcePVC should be set")
+	}
+	return nil
+}
+
+func jobFor(
+	jobName,
+	namespace,
+	pvcName,
+	credSecretName,
+	credSecretNamespace,
+	snapshotID string,
+	resources corev1.ResourceRequirements,
+	labels map[string]string) (*batchv1.Job, error) {
+
+	labels = addJobLabels(labels)
+
+	cmd := strings.Join([]string{
+		"/kopiaexecutor",
+		"delete",
+		"--repository",
+		toRepoName(pvcName, namespace),
+		"--cred-secret-name",
+		credSecretName,
+		"--cred-secret-namespace",
+		credSecretNamespace,
+		"--snapshot-id",
+		snapshotID,
+	}, " ")
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy:    corev1.RestartPolicyOnFailure,
+					ImagePullSecrets: utils.ToImagePullSecret(utils.KopiaExecutorImageSecret()),
+					Containers: []corev1.Container{
+						{
+							Name:  "kopiaexecutor",
+							Image: utils.KopiaExecutorImage(),
+							// TODO: Need to revert it to NotPresent. For now keep it as PullAlways.
+							ImagePullPolicy: corev1.PullAlways,
+							Command: []string{
+								"/bin/sh",
+								"-x",
+								"-c",
+								cmd,
+							},
+							Resources: resources,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "cred-secret",
+									MountPath: drivers.KopiaCredSecretMount,
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "cred-secret",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: credSecretName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func toJobName(snapshotID string) string {
+	return fmt.Sprintf("%s-%s", kopiaDeleteJobPrefix, snapshotID)
+}
+
+func toRepoName(pvcName, pvcNamespace string) string {
+	return fmt.Sprintf("%s-%s", pvcNamespace, pvcName)
+}
+
+func addJobLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	labels[drivers.DriverNameLabel] = drivers.KopiaBackup
+	return labels
+}
+
+func buildJob(jobName string, o drivers.JobOpts) (*batchv1.Job, error) {
+	resources, err := utils.JobResourceRequirements()
+	if err != nil {
+		return nil, err
+	}
+
+	return jobFor(
+		jobName,
+		o.Namespace,
+		o.SourcePVCName,
+		o.CredSecretName,
+		o.CredSecretNamespace,
+		o.SnapshotID,
+		resources,
+		o.Labels,
+	)
+}

--- a/pkg/drivers/options.go
+++ b/pkg/drivers/options.go
@@ -18,7 +18,43 @@ type JobOpts struct {
 	VolumeBackupName        string
 	VolumeBackupNamespace   string
 	DataExportName          string
+	SnapshotID              string
+	CredSecretName          string
+	CredSecretNamespace     string
 	Labels                  map[string]string
+}
+
+// WithSnapshotID is job parameter.
+func WithSnapshotID(snapshotID string) JobOption {
+	return func(opts *JobOpts) error {
+		if strings.TrimSpace(snapshotID) == "" {
+			return fmt.Errorf("snapshotID should be set")
+		}
+		opts.SnapshotID = strings.TrimSpace(snapshotID)
+		return nil
+	}
+}
+
+// WithCredSecretName is job parameter.
+func WithCredSecretName(name string) JobOption {
+	return func(opts *JobOpts) error {
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("cred secret name should be set")
+		}
+		opts.CredSecretName = strings.TrimSpace(name)
+		return nil
+	}
+}
+
+// WithCredSecretNamespace is job parameter.
+func WithCredSecretNamespace(namespace string) JobOption {
+	return func(opts *JobOpts) error {
+		if strings.TrimSpace(namespace) == "" {
+			return fmt.Errorf("cred secret namespace should be set")
+		}
+		opts.CredSecretNamespace = strings.TrimSpace(namespace)
+		return nil
+	}
 }
 
 // WithSourcePVC is job parameter.

--- a/pkg/executor/kopia/kopia.go
+++ b/pkg/executor/kopia/kopia.go
@@ -31,6 +31,7 @@ func NewCommand() *cobra.Command {
 	cmds.AddCommand(
 		newBackupCommand(),
 		newRestoreCommand(),
+		newDeleteCommand(),
 	)
 	cmds.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	err := flag.CommandLine.Parse([]string{})

--- a/pkg/executor/kopia/kopiabackup.go
+++ b/pkg/executor/kopia/kopiabackup.go
@@ -297,6 +297,7 @@ func runKopiaRepositoryConnect(repository *executor.Repository) error {
 		logrus.Errorf("failed connecting to repository %s: %v", repository.Name, err)
 		return err
 	}
+	logrus.Infof("kopia repo connect successful ..")
 
 	return nil
 }

--- a/pkg/executor/kopia/kopiadelete.go
+++ b/pkg/executor/kopia/kopiadelete.go
@@ -1,0 +1,95 @@
+package kopia
+
+import (
+	"fmt"
+
+	"github.com/portworx/kdmp/pkg/executor"
+	"github.com/portworx/kdmp/pkg/kopia"
+	"github.com/portworx/sched-ops/task"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func newDeleteCommand() *cobra.Command {
+	var (
+		snapshotID          string
+		credSecretName      string
+		credSecretNamespace string
+	)
+	deleteCommand := &cobra.Command{
+		Use:   "delete",
+		Short: "delete a backup snapshot",
+		Run: func(c *cobra.Command, args []string) {
+			executor.HandleErr(runDelete(snapshotID))
+		},
+	}
+	deleteCommand.Flags().StringVar(&snapshotID, "snapshot-id", "", "snapshot ID for kopia backup snapshot that need to be deleted")
+	deleteCommand.Flags().StringVar(&credSecretName, "cred-secret-name", "", " cred secret name for kopia backup snapshot that need to be deleted")
+	deleteCommand.Flags().StringVar(&credSecretNamespace, "cred-secret-namespace", "", "cred secret namespace for kopia backup snapshot that need to be deleted")
+	return deleteCommand
+}
+
+func runDelete(snapshotID string) error {
+	// Parse using the mounted secrets
+	fn := "runDelete:"
+	repo, rErr := executor.ParseCloudCred()
+	if rErr != nil {
+		errMsg := fmt.Sprintf("failed in parseing backuplocation: %s", rErr)
+		logrus.Errorf("%s %v", fn, errMsg)
+		return fmt.Errorf(errMsg)
+	}
+
+	repo.Name = frameBackupPath()
+
+	if err := runKopiaRepositoryConnect(repo); err != nil {
+		errMsg := fmt.Sprintf("repository [%v] connect failed: %v", repo.Name, err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		return fmt.Errorf(errMsg)
+	}
+
+	if err := runKopiaDelete(repo, snapshotID); err != nil {
+		errMsg := fmt.Sprintf("snapshot [%v] delete failed: %v", snapshotID, err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		return fmt.Errorf(errMsg)
+	}
+
+	return nil
+}
+
+func runKopiaDelete(repository *executor.Repository, snapshotID string) error {
+	fn := "runKopiaDelete:"
+	deleteCmd, err := kopia.GetDeleteCommand(
+		snapshotID,
+	)
+	if err != nil {
+		errMsg := fmt.Sprintf("getting delete backup snapshot command for snapshot ID [%v] failed: %v", snapshotID, err)
+		logrus.Errorf("%s %v", fn, errMsg)
+		return fmt.Errorf(errMsg)
+	}
+	initExecutor := kopia.NewDeleteExecutor(deleteCmd)
+	if err := initExecutor.Run(); err != nil {
+		errMsg := fmt.Sprintf("running delete backup snapshot command for snapshotID [%v] failed: %v", snapshotID, err)
+		logrus.Errorf("%s %v", fn, errMsg)
+		return fmt.Errorf(errMsg)
+	}
+
+	t := func() (interface{}, bool, error) {
+		status, err := initExecutor.Status()
+		if err != nil {
+			return "", false, err
+		}
+		if status.LastKnownError != nil {
+			return "", false, status.LastKnownError
+		}
+
+		if status.Done {
+			return "", false, nil
+		}
+		return "", true, fmt.Errorf("backup snapshot delete command status not available")
+	}
+	if _, err := task.DoRetryWithTimeout(t, executor.DefaultTimeout, progressCheckInterval); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/kopia/command.go
+++ b/pkg/kopia/command.go
@@ -34,6 +34,8 @@ type Command struct {
 	Password string
 	// Provider storage provider (aws, Google, Azure)
 	Provider string
+	// SnapshotID snapshot ID
+	SnapshotID string
 }
 
 // Executor interface defines APIs for implementing a command wrapper
@@ -162,6 +164,27 @@ func (c *Command) SetPolicyCmd() *exec.Cmd {
 		"policy",
 		c.Name, // set command
 		"--global",
+	}
+	argsSlice = append(argsSlice, c.Flags...)
+	// Get the cmd args
+	argsSlice = append(argsSlice, c.Args...)
+	cmd := exec.Command(baseCmd, argsSlice...)
+	if len(c.Env) > 0 {
+		cmd.Env = append(os.Environ(), c.Env...)
+	}
+	cmd.Dir = c.Dir
+
+	return cmd
+}
+
+// DeleteCmd returns os/exec.Cmd object for the kopia snapshot delete Command
+func (c *Command) DeleteCmd() *exec.Cmd {
+	// Get all the flags
+	argsSlice := []string{
+		"snapshot",
+		c.Name, // delete command
+		c.SnapshotID,
+		"--delete",
 	}
 	argsSlice = append(argsSlice, c.Flags...)
 	// Get the cmd args

--- a/pkg/kopia/delete.go
+++ b/pkg/kopia/delete.go
@@ -1,0 +1,80 @@
+package kopia
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+
+	cmdexec "github.com/portworx/kdmp/pkg/executor"
+	"github.com/sirupsen/logrus"
+)
+
+type deleteExecutor struct {
+	cmd       *Command
+	execCmd   *exec.Cmd
+	outBuf    *bytes.Buffer
+	errBuf    *bytes.Buffer
+	lastError error
+	isRunning bool
+}
+
+// GetDeleteCommand returns a wrapper over the kopia snapshot delete command
+func GetDeleteCommand(snapshotID string) (*Command, error) {
+	return &Command{
+		Name:       "delete",
+		SnapshotID: snapshotID,
+	}, nil
+}
+
+// NewDeleteExecutor returns an instance of Executor that can be used for
+// running a kopia snapshot delete command
+func NewDeleteExecutor(cmd *Command) Executor {
+	return &deleteExecutor{
+		cmd:    cmd,
+		outBuf: new(bytes.Buffer),
+		errBuf: new(bytes.Buffer),
+	}
+}
+
+func (d *deleteExecutor) Run() error {
+	d.execCmd = d.cmd.DeleteCmd()
+	d.execCmd.Stdout = d.outBuf
+	d.execCmd.Stderr = d.errBuf
+
+	if err := d.execCmd.Start(); err != nil {
+		d.lastError = err
+		return err
+	}
+	d.isRunning = true
+	go func() {
+		err := d.execCmd.Wait()
+		if err != nil {
+			d.lastError = fmt.Errorf("failed to run the snapshot delete command: %v", err)
+			logrus.Infof("stdout: %v", d.execCmd.Stdout)
+			logrus.Infof("Stderr: %v", d.execCmd.Stderr)
+		}
+		d.isRunning = false
+	}()
+	return nil
+}
+
+func (d *deleteExecutor) Status() (*cmdexec.Status, error) {
+	if d.lastError != nil {
+		fmt.Fprintln(os.Stderr, d.errBuf.String())
+		return &cmdexec.Status{
+			LastKnownError: d.lastError,
+			Done:           true,
+		}, nil
+	}
+	if d.isRunning {
+		return &cmdexec.Status{
+			Done:           false,
+			LastKnownError: nil,
+		}, nil
+	}
+	return &cmdexec.Status{
+		Done:           true,
+		LastKnownError: nil,
+	}, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
 pb-1859: Added changes for kopia snapshot delete functionality.

        - Added kopia snapshot delete driver
        - Added executor support to invoke kopia snapshot delete
          command.
          
**Which issue(s) this PR fixes** (optional)
Closes # PB-1859

**Special notes for your reviewer**:
**Testing:**
1) Vendor the kdmp vendor code to px-backup. 
2) Added the logic to delete the snapshot, if the driver type is kdmp.
3) Created a normal backup object with few PVC.
4) Created a kopia snapshot offline with a repo.
5) Took the snapshot ID and updated the one of the volume of the backup object to have this snapshot ID and driver type as kdmp.
6) Then tried to deleted the backup object from the UI.
7) Made sure the snapshot is deleted after the completion of the backup object delete.
8) Also verified that delete and container are created and it's content.
9) jobs are deleted automatically after the completion of the snapshot delete.
