### PR TITLE
Changes to DataExport CR for the following

### DIFF
--- a/pkg/apis/kdmp/v1alpha1/dataexport.go
+++ b/pkg/apis/kdmp/v1alpha1/dataexport.go
@@ -116,6 +116,7 @@ type ExportStatus struct {
 	SnapshotPVCNamespace string           `json:"snapshotPVCNamespace,omitempty"`
 	TransferID           string           `json:"transferID,omitempty"`
 	ProgressPercentage   int              `json:"progressPercentage,omitempty"`
+	Size                 uint64           `json:"size,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/drivers/kopiabackup/kopiabackuplive.go
+++ b/pkg/drivers/kopiabackup/kopiabackuplive.go
@@ -23,7 +23,8 @@ func jobForLiveBackup(
 	pvcName,
 	credSecretName,
 	backupLocationName,
-	backuplocationNamespace string,
+	backuplocationNamespace,
+	backupNamespace string,
 	mountPod corev1.Pod,
 	resources corev1.ResourceRequirements,
 	labels map[string]string) (*batchv1.Job, error) {
@@ -52,6 +53,8 @@ func jobForLiveBackup(
 		backupLocationName,
 		"--backup-location-namespace",
 		backuplocationNamespace,
+		"--backup-namespace",
+		backupNamespace,
 		"--repository",
 		toRepoName(pvcName, namespace),
 		"--source-path-glob",

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -20,6 +20,10 @@ import (
 // Driver is a kopiarestore implementation of the data export interface.
 type Driver struct{}
 
+const (
+	restoreJobPrefix = "restore"
+)
+
 // Name returns a name of the driver.
 func (d Driver) Name() string {
 	return drivers.KopiaRestore
@@ -45,7 +49,7 @@ func (d Driver) StartJob(opts ...drivers.JobOption) (id string, err error) {
 		return "", err
 	}
 
-	jobName := toJobName(o.DataExportName, o.DestinationPVCName)
+	jobName := toJobName(o.DataExportName)
 	job, err := jobFor(
 		jobName,
 		o.Namespace,
@@ -226,8 +230,8 @@ func jobFor(
 	}, nil
 }
 
-func toJobName(dataExportName, pvcName string) string {
-	return fmt.Sprintf("%s-%s", dataExportName, pvcName)
+func toJobName(dataExportName string) string {
+	return fmt.Sprintf("%s-%s", restoreJobPrefix, dataExportName)
 }
 
 func addJobLabels(labels map[string]string) map[string]string {

--- a/pkg/executor/common.go
+++ b/pkg/executor/common.go
@@ -394,7 +394,7 @@ func WriteVolumeBackupStatus(
 }
 
 // CreateVolumeBackup creates volumebackup CRD
-func CreateVolumeBackup(name, namespace, repository, blName string) error {
+func CreateVolumeBackup(name, namespace, repository, blName, blNamespace string) error {
 	new := &kdmpapi.VolumeBackup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -404,7 +404,7 @@ func CreateVolumeBackup(name, namespace, repository, blName string) error {
 			Repository: repository,
 			BackupLocation: kdmpapi.DataExportObjectReference{
 				Name:      blName,
-				Namespace: namespace,
+				Namespace: blNamespace,
 			},
 		},
 	}

--- a/pkg/executor/kopia/kopia.go
+++ b/pkg/executor/kopia/kopia.go
@@ -9,11 +9,11 @@ import (
 )
 
 var (
-	namespace          string
-	volumeBackupName   string
-	kopiaRepo          string
-	credentials        string
-	backupLocationName string
+	volumeBackupName        string
+	kopiaRepo               string
+	credentials             string
+	backupLocationName      string
+	backupLocationNamespace string
 )
 
 // NewCommand returns a kopia command wrapper
@@ -27,6 +27,7 @@ func NewCommand() *cobra.Command {
 	cmds.PersistentFlags().StringVar(&kopiaRepo, "repository", "", "Name of the kopia repository. If provided it will overwrite the BackupLocation one")
 	cmds.PersistentFlags().StringVarP(&credentials, "credentials", "c", "", "Secret holding repository credentials")
 	cmds.PersistentFlags().StringVar(&backupLocationName, "backup-location", "", "Name of the BackupLocation object, used for authentication")
+	cmds.PersistentFlags().StringVar(&backupLocationNamespace, "backup-location-namespace", "", "Namespace of BackupLocation object, used for authentication")
 
 	cmds.AddCommand(
 		newBackupCommand(),

--- a/pkg/executor/kopia/kopiabackup.go
+++ b/pkg/executor/kopia/kopiabackup.go
@@ -29,6 +29,10 @@ const (
 	latestSnapshots       = "2147483647"
 )
 
+var (
+	bkpNamespace string
+)
+
 func newBackupCommand() *cobra.Command {
 	var (
 		sourcePath     string
@@ -47,7 +51,7 @@ func newBackupCommand() *cobra.Command {
 			executor.HandleErr(runBackup(srcPath))
 		},
 	}
-	backupCommand.Flags().StringVarP(&namespace, "backup-location-namespace", "n", "", "Namespace for backup command")
+	backupCommand.Flags().StringVarP(&bkpNamespace, "backup-namespace", "n", "", "Namespace for backup command")
 	backupCommand.Flags().StringVar(&sourcePath, "source-path", "", "Source for kopia backup")
 	backupCommand.Flags().StringVar(&sourcePathGlob, "source-path-glob", "", "The regexp should match only one path that will be used for backup")
 	backupCommand.Flags().StringVar(&volumeBackupName, "volume-backup-name", "", "Provided VolumeBackup CRD will be updated with the latest backup progress details")
@@ -70,9 +74,10 @@ func runBackup(sourcePath string) error {
 	if volumeBackupName != "" {
 		if err := executor.CreateVolumeBackup(
 			volumeBackupName,
-			namespace,
+			bkpNamespace,
 			repoName,
 			backupLocationName,
+			backupLocationNamespace,
 		); err != nil {
 			logrus.Errorf("%s: %v", fn, err)
 			return err
@@ -82,7 +87,7 @@ func runBackup(sourcePath string) error {
 		if statusErr := executor.WriteVolumeBackupStatus(
 			&executor.Status{LastKnownError: rErr},
 			volumeBackupName,
-			namespace,
+			bkpNamespace,
 		); statusErr != nil {
 			return statusErr
 		}
@@ -189,7 +194,7 @@ func runKopiaCreateRepo(repository *executor.Repository) error {
 				if err = executor.WriteVolumeBackupStatus(
 					status,
 					volumeBackupName,
-					namespace,
+					bkpNamespace,
 				); err != nil {
 					errMsg := fmt.Sprintf("failed to write a VolumeBackup status: %v", err)
 					logrus.Errorf("%v", errMsg)
@@ -203,7 +208,7 @@ func runKopiaCreateRepo(repository *executor.Repository) error {
 		if err = executor.WriteVolumeBackupStatus(
 			status,
 			volumeBackupName,
-			namespace,
+			bkpNamespace,
 		); err != nil {
 			errMsg := fmt.Sprintf("failed to write a VolumeBackup status: %v", err)
 			logrus.Errorf("%v", errMsg)
@@ -254,7 +259,7 @@ func runKopiaBackup(repository *executor.Repository, sourcePath string) error {
 			if err = executor.WriteVolumeBackupStatus(
 				status,
 				volumeBackupName,
-				namespace,
+				bkpNamespace,
 			); err != nil {
 				errMsg := fmt.Sprintf("failed to write a VolumeBackup status: %v", err)
 				logrus.Errorf("%v", errMsg)
@@ -266,7 +271,7 @@ func runKopiaBackup(repository *executor.Repository, sourcePath string) error {
 		if err = executor.WriteVolumeBackupStatus(
 			status,
 			volumeBackupName,
-			namespace,
+			bkpNamespace,
 		); err != nil {
 			errMsg := fmt.Sprintf("failed to write a VolumeBackup status: %v", err)
 			logrus.Errorf("%v", errMsg)
@@ -319,7 +324,7 @@ func runKopiaRepositoryConnect(repository *executor.Repository) error {
 			if err = executor.WriteVolumeBackupStatus(
 				status,
 				volumeBackupName,
-				namespace,
+				bkpNamespace,
 			); err != nil {
 				errMsg := fmt.Sprintf("failed to write a VolumeBackup status: %v", err)
 				logrus.Errorf("%v", errMsg)
@@ -367,7 +372,7 @@ func setGlobalPolicy() error {
 			if err = executor.WriteVolumeBackupStatus(
 				status,
 				volumeBackupName,
-				namespace,
+				bkpNamespace,
 			); err != nil {
 				errMsg := fmt.Sprintf("failed to write a VolumeBackup status: %v", err)
 				logrus.Errorf("%v", errMsg)

--- a/pkg/executor/restic/resticbackup.go
+++ b/pkg/executor/restic/resticbackup.go
@@ -62,6 +62,7 @@ func runBackup(sourcePath string) error {
 			namespace,
 			repo.Name,
 			backupLocationName,
+			namespace,
 		); err != nil {
 			return err
 		}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,7 +9,7 @@ import (
 //
 // These variables typically come from -ldflags settings.
 var (
-	gitVersion = "raw"
+	gitVersion = "master"
 	gitCommit  = ""                     // sha1 from git, output of $(git rev-parse HEAD)
 	buildDate  = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
- Storing snapshotID from VolumeBackup CR into DatExport CR
- Creation of secret in source/destination ns for handling multi ns use case
  where stork backup/restore/BL CR's are present in kube-system
- Deletion of VolumeBackup CR after a successful backup


**Which issue(s) this PR fixes** (optional)
PB-1870

**Special notes for your reviewer**:

Manual Test
Updated DataExport CR

```
[root@prashanth-iron-seer-0 kdmp]# k describe dataexport kopia-aws-mysql-1 -nrst
Name:         kopia-aws-mysql-1
Namespace:    rst
Labels:       <none>
Annotations:  <none>
API Version:  kdmp.portworx.com/v1alpha1
Kind:         DataExport
Metadata:
  Creation Timestamp:  2021-09-14T15:05:31Z
  Finalizers:
    kdmp.portworx.com/finalizer-cleanup

Spec:
  Destination:
    API Version:  stork.libopenstorage.org/v1alpha1
    Kind:         BackupLocation
    Name:         kopia-bl
    Namespace:    kube-system
  Source:
    API Version:  v1
    Kind:         PersistentVolumeClaim
    Name:         mysql-data
    Namespace:    rst
  Type:           kopia
Status:
  Snapshot ID:  5cfcfd8453e76988c913a3daac3f8763
  Stage:        Final
  Status:       Successful
  Transfer ID:  rst/kopia-aws-mysql-1-mysql-data
Events:         <none>
```