### PR TITLE
pb-1876: Added executor and driver for maintenance.

### DIFF
--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -4,12 +4,13 @@ import "fmt"
 
 // Known drivers.
 const (
-	Rsync         = "rsync"
-	ResticBackup  = "resticbackup"
-	ResticRestore = "resticrestore"
-	KopiaBackup   = "kopiabackup"
-	KopiaRestore  = "kopiarestore"
-	KopiaDelete   = "kopiadelete"
+	Rsync            = "rsync"
+	ResticBackup     = "resticbackup"
+	ResticRestore    = "resticrestore"
+	KopiaBackup      = "kopiabackup"
+	KopiaRestore     = "kopiarestore"
+	KopiaDelete      = "kopiadelete"
+	KopiaMaintenance = "kopiamaintenance"
 )
 
 // Docker images.

--- a/pkg/drivers/driversinstance/driversinstance.go
+++ b/pkg/drivers/driversinstance/driversinstance.go
@@ -7,6 +7,7 @@ import (
 	"github.com/portworx/kdmp/pkg/drivers"
 	"github.com/portworx/kdmp/pkg/drivers/kopiabackup"
 	"github.com/portworx/kdmp/pkg/drivers/kopiadelete"
+	"github.com/portworx/kdmp/pkg/drivers/kopiamaintenance"
 	"github.com/portworx/kdmp/pkg/drivers/kopiarestore"
 	"github.com/portworx/kdmp/pkg/drivers/resticbackup"
 	"github.com/portworx/kdmp/pkg/drivers/resticrestore"
@@ -16,12 +17,13 @@ import (
 var (
 	mu         sync.Mutex
 	driversMap = map[string]drivers.Interface{
-		drivers.Rsync:         rsync.Driver{},
-		drivers.ResticBackup:  resticbackup.Driver{},
-		drivers.ResticRestore: resticrestore.Driver{},
-		drivers.KopiaBackup:   kopiabackup.Driver{},
-		drivers.KopiaRestore:  kopiarestore.Driver{},
-		drivers.KopiaDelete:   kopiadelete.Driver{},
+		drivers.Rsync:            rsync.Driver{},
+		drivers.ResticBackup:     resticbackup.Driver{},
+		drivers.ResticRestore:    resticrestore.Driver{},
+		drivers.KopiaBackup:      kopiabackup.Driver{},
+		drivers.KopiaRestore:     kopiarestore.Driver{},
+		drivers.KopiaDelete:      kopiadelete.Driver{},
+		drivers.KopiaMaintenance: kopiamaintenance.Driver{},
 	}
 )
 

--- a/pkg/drivers/kopiamaintenance/kopiamaintenance.go
+++ b/pkg/drivers/kopiamaintenance/kopiamaintenance.go
@@ -1,0 +1,225 @@
+package kopiamaintenance
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/portworx/kdmp/pkg/drivers"
+	"github.com/portworx/kdmp/pkg/drivers/utils"
+	"github.com/portworx/sched-ops/k8s/batch"
+	"github.com/sirupsen/logrus"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	kopiaMaintenanceJobPrefix = "repo-maintenance"
+	// TODO: for now setting it to 30 mints for testing purpose.
+	// Will change it to 24 hours later.
+	defaultSchedule = "*/30 * * * *"
+)
+
+// Driver is a kopia maintenance snapshot implementation
+type Driver struct{}
+
+// Name returns a name of the driver.
+func (d Driver) Name() string {
+	return drivers.KopiaMaintenance
+}
+
+// StartJob creates a cron job for kopia snapshot maintenance
+// Note: Not added separate interface apis for cronjob. Reused job apis to start the cron job.
+func (d Driver) StartJob(opts ...drivers.JobOption) (id string, err error) {
+	fn := "StartJob:"
+	o := drivers.JobOpts{}
+	for _, opt := range opts {
+		if opt != nil {
+			if err := opt(&o); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	if err := d.validate(o); err != nil {
+		errMsg := fmt.Sprintf("validation failed for maintenance job for backuplocation [%v]: %v", o.BackupLocationName, err)
+		logrus.Infof("%s %v", fn, errMsg)
+		return "", fmt.Errorf(errMsg)
+	}
+	jobName := toJobName(o.BackupLocationName)
+	job, err := buildJob(jobName, o)
+	if err != nil {
+		errMsg := fmt.Sprintf("building maintenance job [%s] for backuplocation [%v] failed: %v", jobName, o.BackupLocationName, err)
+		logrus.Errorf("%s %v", fn, errMsg)
+		return "", fmt.Errorf(errMsg)
+	}
+	if _, err = batch.Instance().CreateCronJob(job); err != nil && !apierrors.IsAlreadyExists(err) {
+		errMsg := fmt.Sprintf("creation of maintenance job [%s] for backuplocation [%v] failed: %v", jobName, o.BackupLocationName, err)
+		logrus.Errorf("%s %v", fn, errMsg)
+		return "", fmt.Errorf(errMsg)
+	}
+	logrus.Infof("%s created maintenance job [%s] for backuplocation [%v] successfully", fn, o.BackupLocationName, job.Name)
+	return utils.NamespacedName(job.Namespace, job.Name), nil
+}
+
+// DeleteJob deletes the maintenance job.
+func (d Driver) DeleteJob(id string) error {
+	fn := "DeleteJob:"
+	namespace, name, err := utils.ParseJobID(id)
+	if err != nil {
+		logrus.Errorf("%s %v", fn, err)
+		return err
+	}
+
+	if err = batch.Instance().DeleteCronJob(name, namespace); err != nil && !apierrors.IsNotFound(err) {
+		errMsg := fmt.Sprintf("deletion of maintenance job [%s/%s] failed: %v", namespace, name, err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		return fmt.Errorf(errMsg)
+	}
+	logrus.Infof("deleted maintenance cron job [%s/%s] successfully", namespace, name)
+	return nil
+}
+
+// JobStatus returns a progress of the maintenance cron job.
+func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
+	fn := "JobStatus"
+	namespace, name, err := utils.ParseJobID(id)
+	if err != nil {
+		return utils.ToJobStatus(0, err.Error()), nil
+	}
+
+	job, err := batch.Instance().GetJob(name, namespace)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to fetch maintenance [%s/%s] job: %v", namespace, name, err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+	if utils.IsJobFailed(job) {
+		errMsg := fmt.Sprintf("check maintenance [%s/%s] job for details: %s", namespace, name, drivers.ErrJobFailed)
+		return utils.ToJobStatus(0, errMsg), nil
+	}
+	if utils.IsJobCompleted(job) {
+		return utils.ToJobStatus(drivers.TransferProgressCompleted, ""), nil
+	}
+	return utils.ToJobStatus(0, ""), nil
+}
+
+func (d Driver) validate(o drivers.JobOpts) error {
+	if o.CredSecretName == "" {
+		return fmt.Errorf("credential secret name should be set")
+	}
+	if o.CredSecretNamespace == "" {
+		return fmt.Errorf("credential secret namespace  should be set")
+	}
+	return nil
+}
+
+func jobFor(
+	jobName,
+	credSecretName,
+	credSecretNamespace string,
+	resources corev1.ResourceRequirements,
+	labels map[string]string) (*batchv1beta1.CronJob, error) {
+
+	labels = addJobLabels(labels)
+
+	cmd := strings.Join([]string{
+		"/kopiaexecutor",
+		"maintenance",
+		"--cred-secret-name",
+		credSecretName,
+		"--cred-secret-namespace",
+		credSecretNamespace,
+	}, " ")
+
+	return &batchv1beta1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: credSecretNamespace,
+			Labels:    labels,
+		},
+		Spec: batchv1beta1.CronJobSpec{
+			Schedule: defaultSchedule,
+			JobTemplate: batchv1beta1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      jobName,
+					Namespace: credSecretNamespace,
+					Labels:    labels,
+				},
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: labels,
+						},
+						Spec: corev1.PodSpec{
+							RestartPolicy:    corev1.RestartPolicyOnFailure,
+							ImagePullSecrets: utils.ToImagePullSecret(utils.KopiaExecutorImageSecret()),
+							Containers: []corev1.Container{
+								{
+									Name:  "kopiaexecutor",
+									Image: utils.KopiaExecutorImage(),
+									// TODO: Need to revert it to NotPresent. For now keep it as PullAlways.
+									ImagePullPolicy: corev1.PullAlways,
+									Command: []string{
+										"/bin/sh",
+										"-x",
+										"-c",
+										cmd,
+									},
+									Resources: resources,
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "cred-secret",
+											MountPath: drivers.KopiaCredSecretMount,
+											ReadOnly:  true,
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "cred-secret",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: credSecretName,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func toJobName(backupLocation string) string {
+	return fmt.Sprintf("%s-%s", kopiaMaintenanceJobPrefix, backupLocation)
+}
+
+func addJobLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	labels[drivers.DriverNameLabel] = drivers.KopiaBackup
+	return labels
+}
+
+func buildJob(jobName string, o drivers.JobOpts) (*batchv1beta1.CronJob, error) {
+	resources, err := utils.JobResourceRequirements()
+	if err != nil {
+		return nil, err
+	}
+
+	return jobFor(
+		jobName,
+		o.CredSecretName,
+		o.CredSecretNamespace,
+		resources,
+		o.Labels,
+	)
+}

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -17,12 +17,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Driver is a kopiarestore implementation of the data export interface.
-type Driver struct{}
-
 const (
 	restoreJobPrefix = "restore"
 )
+
+// Driver is a kopiarestore implementation of the data export interface.
+type Driver struct{}
 
 // Name returns a name of the driver.
 func (d Driver) Name() string {

--- a/pkg/executor/kopia/kopia.go
+++ b/pkg/executor/kopia/kopia.go
@@ -33,6 +33,7 @@ func NewCommand() *cobra.Command {
 		newBackupCommand(),
 		newRestoreCommand(),
 		newDeleteCommand(),
+		newMaintenanceCommand(),
 	)
 	cmds.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	err := flag.CommandLine.Parse([]string{})

--- a/pkg/executor/kopia/kopiabackup.go
+++ b/pkg/executor/kopia/kopiabackup.go
@@ -464,7 +464,6 @@ func isRepositoryExists(repository *executor.Repository) (bool, error) {
 	}
 	return exists, nil
 }
-
 func addPolicySetting(policyCmd *kopia.Command) *kopia.Command {
 	policyCmd.AddArg("--keep-latest")
 	policyCmd.AddArg(latestSnapshots)

--- a/pkg/executor/kopia/maintenance.go
+++ b/pkg/executor/kopia/maintenance.go
@@ -1,0 +1,191 @@
+package kopia
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/libopenstorage/stork/pkg/objectstore"
+	"github.com/portworx/kdmp/pkg/executor"
+	"github.com/portworx/kdmp/pkg/kopia"
+	"github.com/portworx/sched-ops/task"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gocloud.dev/blob"
+)
+
+func newMaintenanceCommand() *cobra.Command {
+	var (
+		credSecretName      string
+		credSecretNamespace string
+	)
+	maintenanceCommand := &cobra.Command{
+		Use:   "maintenance",
+		Short: "maintenance for repo",
+		Run: func(c *cobra.Command, args []string) {
+			executor.HandleErr(runMaintenance())
+		},
+	}
+	maintenanceCommand.Flags().StringVar(&credSecretName, "cred-secret-name", "", " cred secret name for the repository to run maintenance command")
+	maintenanceCommand.Flags().StringVar(&credSecretNamespace, "cred-secret-namespace", "", "cred secret namespace for the repository to run maintenance command")
+	return maintenanceCommand
+}
+
+// getRepoList - This function will return possible repo in the given bucket blob.
+func getRepoList(bucket *blob.Bucket) ([]string, error) {
+	// Get the list of repo in the bucket
+	iterator := bucket.List(&blob.ListOptions{
+		Delimiter: "/",
+	})
+	repoList := make([]string, 0)
+	for {
+		object, err := iterator.Next(context.TODO())
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			logrus.Errorf("getRepolist: err %v", err)
+			return repoList, err
+		}
+		tempBucket := blob.PrefixedBucket(bucket, object.Key)
+		exists, err := tempBucket.Exists(context.TODO(), kopiaRepositoryFile)
+		if err != nil {
+			logrus.Errorf("getRepoList: checking for presence of %v file failed: %v", err, kopiaRepositoryFile)
+			continue
+		}
+		if exists {
+			repoList = append(repoList, object.Key)
+		}
+	}
+	return repoList, nil
+}
+
+func runMaintenance() error {
+	// Parse using the mounted secrets
+	fn := "runMaintenance:"
+	repo, rErr := executor.ParseCloudCred()
+	if rErr != nil {
+		errMsg := fmt.Sprintf("failed in parsing backuplocation: %s", rErr)
+		logrus.Errorf("%s %v", fn, errMsg)
+		return fmt.Errorf(errMsg)
+	}
+	bl, err := buildStorkBackupLocation(repo)
+	if err != nil {
+		logrus.Errorf("%v", err)
+		return err
+	}
+	bucket, err := objectstore.GetBucket(bl)
+	if err != nil {
+		logrus.Errorf("getting bucket details for [%v] failed: %v", repo.Path, err)
+		return err
+	}
+	// The generic backup will be created under generic-backups/ directory in a bucket.
+	// So, to get the list of repo in the bucket, get list of enteries under genric-backup dir.
+	repo.Name = genericBackupDir + "/"
+	bucket = blob.PrefixedBucket(bucket, repo.Name)
+	repoList, err := getRepoList(bucket)
+	if err != nil {
+		logrus.Errorf("getting repo list failed for bucket [%v]: %v", repo.Path, err)
+		return err
+	}
+	for _, repoName := range repoList {
+		repo.Name = getBackupPathWithRepoName(repoName)
+
+		if err := runKopiaRepositoryConnect(repo); err != nil {
+			errMsg := fmt.Sprintf("repository [%v] connect failed: %v", repo.Name, err)
+			logrus.Errorf("%s: %v", fn, errMsg)
+			return fmt.Errorf(errMsg)
+		}
+		logrus.Infof("connect to repo completed successfully for repository [%v]", repo.Name)
+
+		if err := runKopiaMaintenanceSet(repo); err != nil {
+			errMsg := fmt.Sprintf("maintenance owner set command failed for repo [%v]: %v", repo.Name, err)
+			logrus.Errorf("%s: %v", fn, errMsg)
+			return fmt.Errorf(errMsg)
+		}
+		logrus.Infof("maintenance set owner command completed successfully for repository [%v]", repo.Name)
+		if err := runKopiaMaintenanceExecute(repo); err != nil {
+			errMsg := fmt.Sprintf("maintenance full run command failed for repo [%v]: %v", repo.Name, err)
+			logrus.Errorf("%s: %v", fn, errMsg)
+			return fmt.Errorf(errMsg)
+		}
+		logrus.Infof("maintenance full run command completed successfully for repository [%v]", repo.Name)
+	}
+
+	return nil
+}
+
+func getBackupPathWithRepoName(repoName string) string {
+	return genericBackupDir + "/" + repoName
+}
+func runKopiaMaintenanceExecute(repository *executor.Repository) error {
+	fn := "runKopiaMaintenanceRun:"
+	maintenanceRunCmd, err := kopia.GetMaintenanceRunCommand()
+	if err != nil {
+		errMsg := fmt.Sprintf("getting maintenance run command for [%v] failed: %v", repository.Name, err)
+		logrus.Errorf("%s %v", fn, errMsg)
+		return fmt.Errorf(errMsg)
+	}
+	initExecutor := kopia.NewMaintenanceRunExecutor(maintenanceRunCmd)
+	if err := initExecutor.Run(); err != nil {
+		errMsg := fmt.Sprintf("running maintenance run command for [%v] failed: %v", repository.Name, err)
+		logrus.Errorf("%s %v", fn, errMsg)
+		return fmt.Errorf(errMsg)
+	}
+
+	t := func() (interface{}, bool, error) {
+		status, err := initExecutor.Status()
+		if err != nil {
+			return "", false, err
+		}
+		if status.LastKnownError != nil {
+			return "", false, status.LastKnownError
+		}
+
+		if status.Done {
+			return "", false, nil
+		}
+		return "", true, fmt.Errorf("maintenance run command status not available")
+	}
+	if _, err := task.DoRetryWithTimeout(t, executor.DefaultTimeout, progressCheckInterval); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func runKopiaMaintenanceSet(repository *executor.Repository) error {
+	fn := "runKopiaMaintenanceSet:"
+	maintenanceSetCmd, err := kopia.GetMaintenanceSetCommand()
+	if err != nil {
+		errMsg := fmt.Sprintf("getting maintenance set command for failed: %v", err)
+		logrus.Errorf("%s %v", fn, errMsg)
+		return fmt.Errorf(errMsg)
+	}
+	initExecutor := kopia.NewMaintenanceSetExecutor(maintenanceSetCmd)
+	if err := initExecutor.Run(); err != nil {
+		errMsg := fmt.Sprintf("running maintenance set command for failed: %v", err)
+		logrus.Errorf("%s %v", fn, errMsg)
+		return fmt.Errorf(errMsg)
+	}
+
+	t := func() (interface{}, bool, error) {
+		status, err := initExecutor.Status()
+		if err != nil {
+			return "", false, err
+		}
+		if status.LastKnownError != nil {
+			return "", false, status.LastKnownError
+		}
+
+		if status.Done {
+			return "", false, nil
+		}
+		return "", true, fmt.Errorf("maintenance set command status not available")
+	}
+	if _, err := task.DoRetryWithTimeout(t, executor.DefaultTimeout, progressCheckInterval); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/kopia/command.go
+++ b/pkg/kopia/command.go
@@ -36,6 +36,8 @@ type Command struct {
 	Provider string
 	// SnapshotID snapshot ID
 	SnapshotID string
+	// MaintenanceOwner owner of maintenance command
+	MaintenanceOwner string
 }
 
 // Executor interface defines APIs for implementing a command wrapper
@@ -214,6 +216,48 @@ func (c *Command) DeleteCmd() *exec.Cmd {
 		c.Name, // delete command
 		c.SnapshotID,
 		"--delete",
+	}
+	argsSlice = append(argsSlice, c.Flags...)
+	// Get the cmd args
+	argsSlice = append(argsSlice, c.Args...)
+	cmd := exec.Command(baseCmd, argsSlice...)
+	if len(c.Env) > 0 {
+		cmd.Env = append(os.Environ(), c.Env...)
+	}
+	cmd.Dir = c.Dir
+
+	return cmd
+}
+
+// MaintenanceRunCmd returns os/exec.Cmd object for the kopia maintenance run Command
+func (c *Command) MaintenanceRunCmd() *exec.Cmd {
+	// Get all the flags
+	argsSlice := []string{
+		c.Name, // maintenance command
+		"run",
+		"--full",
+	}
+	argsSlice = append(argsSlice, c.Flags...)
+	// Get the cmd args
+	argsSlice = append(argsSlice, c.Args...)
+	cmd := exec.Command(baseCmd, argsSlice...)
+	if len(c.Env) > 0 {
+		cmd.Env = append(os.Environ(), c.Env...)
+	}
+	cmd.Dir = c.Dir
+
+	return cmd
+}
+
+// MaintenanceSetCmd returns os/exec.Cmd object for the kopia maintenance set Command
+func (c *Command) MaintenanceSetCmd() *exec.Cmd {
+	// Get all the flags
+
+	argsSlice := []string{
+		c.Name, // maintenance command
+		"set",
+		"--owner",
+		c.MaintenanceOwner,
 	}
 	argsSlice = append(argsSlice, c.Flags...)
 	// Get the cmd args

--- a/pkg/kopia/maintenancerun.go
+++ b/pkg/kopia/maintenancerun.go
@@ -1,0 +1,79 @@
+package kopia
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+
+	cmdexec "github.com/portworx/kdmp/pkg/executor"
+	"github.com/sirupsen/logrus"
+)
+
+type maintenanceRunExecutor struct {
+	cmd       *Command
+	execCmd   *exec.Cmd
+	outBuf    *bytes.Buffer
+	errBuf    *bytes.Buffer
+	lastError error
+	isRunning bool
+}
+
+// GetMaintenanceRunCommand returns a wrapper over the kopia repo maintenance run command
+func GetMaintenanceRunCommand() (*Command, error) {
+	return &Command{
+		Name: "maintenance",
+	}, nil
+}
+
+// NewMaintenanceRunExecutor returns an instance of Executor that can be used for
+// running a kopia repo maintenance command
+func NewMaintenanceRunExecutor(cmd *Command) Executor {
+	return &maintenanceRunExecutor{
+		cmd:    cmd,
+		outBuf: new(bytes.Buffer),
+		errBuf: new(bytes.Buffer),
+	}
+}
+
+func (mr *maintenanceRunExecutor) Run() error {
+	mr.execCmd = mr.cmd.MaintenanceRunCmd()
+	mr.execCmd.Stdout = mr.outBuf
+	mr.execCmd.Stderr = mr.errBuf
+
+	if err := mr.execCmd.Start(); err != nil {
+		mr.lastError = err
+		return err
+	}
+	mr.isRunning = true
+	go func() {
+		err := mr.execCmd.Wait()
+		if err != nil {
+			mr.lastError = fmt.Errorf("failed to run the repo maintenance command: %v", err)
+			logrus.Infof("stdout: %v", mr.execCmd.Stdout)
+			logrus.Infof("Stderr: %v", mr.execCmd.Stderr)
+		}
+		mr.isRunning = false
+	}()
+	return nil
+}
+
+func (mr *maintenanceRunExecutor) Status() (*cmdexec.Status, error) {
+	if mr.lastError != nil {
+		fmt.Fprintln(os.Stderr, mr.errBuf.String())
+		return &cmdexec.Status{
+			LastKnownError: mr.lastError,
+			Done:           true,
+		}, nil
+	}
+	if mr.isRunning {
+		return &cmdexec.Status{
+			Done:           false,
+			LastKnownError: nil,
+		}, nil
+	}
+	return &cmdexec.Status{
+		Done:           true,
+		LastKnownError: nil,
+	}, nil
+}

--- a/pkg/kopia/maintenanceset.go
+++ b/pkg/kopia/maintenanceset.go
@@ -1,0 +1,92 @@
+package kopia
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+
+	cmdexec "github.com/portworx/kdmp/pkg/executor"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	rootUser = "root@"
+)
+
+type maintenanceSetExecutor struct {
+	cmd       *Command
+	execCmd   *exec.Cmd
+	outBuf    *bytes.Buffer
+	errBuf    *bytes.Buffer
+	lastError error
+	isRunning bool
+}
+
+// GetMaintenanceSetCommand returns a wrapper over the kopia repo maintenance set command
+func GetMaintenanceSetCommand() (*Command, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		errMsg := fmt.Sprintf("failed in getting hostname: %v", err)
+		logrus.Infof("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+	owner := rootUser + hostname
+	logrus.Debugf("GetMaintenanceSetCommand: owner %v", owner)
+	return &Command{
+		Name:             "maintenance",
+		MaintenanceOwner: owner,
+	}, nil
+}
+
+// NewMaintenanceSetExecutor returns an instance of Executor that can be used for
+// running a kopia repo maintenance command
+func NewMaintenanceSetExecutor(cmd *Command) Executor {
+	return &maintenanceSetExecutor{
+		cmd:    cmd,
+		outBuf: new(bytes.Buffer),
+		errBuf: new(bytes.Buffer),
+	}
+}
+
+func (ms *maintenanceSetExecutor) Run() error {
+	ms.execCmd = ms.cmd.MaintenanceSetCmd()
+	ms.execCmd.Stdout = ms.outBuf
+	ms.execCmd.Stderr = ms.errBuf
+
+	if err := ms.execCmd.Start(); err != nil {
+		ms.lastError = err
+		return err
+	}
+	ms.isRunning = true
+	go func() {
+		err := ms.execCmd.Wait()
+		if err != nil {
+			ms.lastError = fmt.Errorf("failed to run the repo maintenance set command: %v", err)
+			logrus.Infof("stdout: %v", ms.execCmd.Stdout)
+			logrus.Infof("Stderr: %v", ms.execCmd.Stderr)
+		}
+		ms.isRunning = false
+	}()
+	return nil
+}
+
+func (ms *maintenanceSetExecutor) Status() (*cmdexec.Status, error) {
+	if ms.lastError != nil {
+		fmt.Fprintln(os.Stderr, ms.errBuf.String())
+		return &cmdexec.Status{
+			LastKnownError: ms.lastError,
+			Done:           true,
+		}, nil
+	}
+	if ms.isRunning {
+		return &cmdexec.Status{
+			Done:           false,
+			LastKnownError: nil,
+		}, nil
+	}
+	return &cmdexec.Status{
+		Done:           true,
+		LastKnownError: nil,
+	}, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
```
 pb-1876: Added executor and driver for maintenance.

        - Added driver interface api for running kopia maintenance set
          and run command.
        - Also added a executor to call the kopia maintenance set and
          run command.
        - cronJob will go through all the repos present in the
          given backuplocation.
 ```
**Which issue(s) this PR fixes** (optional)
Closes #
PB-1876

**Special notes for your reviewer**:
**Pending items:**
**1) Single PR is becoming bigger, Currently I am not creating the BackupLocationMaintenance CR for status update. I will take it up in separate PR.
2) Also the deletion of CronJobs while deleting the backuplocation.**

**Testing:**
1) Offline created a bucket in minio with generic-backups as directory in it and added two repos using kopia repository create command.
2) Then added the backuplocation in the px-backup, where the startJob for maintenance is called. It created a cronJob for the backuplocation.
3) For testing purpose changed the schedule interval to 5 minutes and checked that maintenance jobs are created in the regular interval of 5 minutes. Also verified from the log that maintenance set and run commands are executed for both the repos present under the generic-backups directory.

```
[root@central-muck-dog-0 ~]# kubectl get cronjob -n px-backup
NAME                      SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
repo-maintenance-siva14   */5 * * * *   False     1        118s            4h12m
[root@central-muck-dog-0 ~]#
```
```
[root@central-muck-dog-0 ~]# kubectl describe cronjob -n px-backup
Name:                          repo-maintenance-siva14
Namespace:                     px-backup
Labels:                        kdmp.portworx.com/driver-name=kopiabackup
Annotations:                   <none>
Schedule:                      */5 * * * *
Concurrency Policy:            Allow
Suspend:                       False
Successful Job History Limit:  3
Failed Job History Limit:      1
Starting Deadline Seconds:     <unset>
Selector:                      <unset>
Parallelism:                   <unset>
Completions:                   <unset>
Pod Template:
  Labels:  kdmp.portworx.com/driver-name=kopiabackup
  Containers:
   kopiaexecutor:
    Image:      sivaportworx/kopiaexecutor:latest
    Port:       <none>
    Host Port:  <none>
    Command:
      /bin/sh
      -x
      -c
      /kopiaexecutor maintenance --cred-secret-name siva14-32dbaa4 --cred-secret-namespace px-backup
    Limits:
      cpu:     2
      memory:  1Gi
    Requests:
      cpu:        1
      memory:     700Mi
    Environment:  <none>
    Mounts:
      /etc/cred-secret from cred-secret (ro)
  Volumes:
   cred-secret:
    Type:            Secret (a volume populated by a Secret)
    SecretName:      siva14-32dbaa4
    Optional:        false
Last Schedule Time:  Wed, 15 Sep 2021 12:45:00 +0000
Active Jobs:         <none>
Events:
  Type    Reason           Age                  From                Message
  ----    ------           ----                 ----                -------
  Normal  SawCompletedJob  12s (x23 over 155m)  cronjob-controller  (combined from similar events): Saw completed job: repo-maintenance-siva14-1631709900, status: Complete
[root@central-muck-dog-0 ~]#
```
```
[root@central-muck-dog-0 ~]# kubectl describe jobs repo-maintenance-siva14-1631709900 -n px-backup
Name:           repo-maintenance-siva14-1631709900
Namespace:      px-backup
Selector:       controller-uid=a5327dcc-3db8-4f4f-9e6c-9362871dd4ab
Labels:         kdmp.portworx.com/driver-name=kopiabackup
Annotations:    <none>
Controlled By:  CronJob/repo-maintenance-siva14
Parallelism:    1
Completions:    1
Start Time:     Wed, 15 Sep 2021 12:45:09 +0000
Completed At:   Wed, 15 Sep 2021 12:47:06 +0000
Duration:       117s
Pods Statuses:  0 Running / 1 Succeeded / 0 Failed
Pod Template:
  Labels:  controller-uid=a5327dcc-3db8-4f4f-9e6c-9362871dd4ab
           job-name=repo-maintenance-siva14-1631709900
           kdmp.portworx.com/driver-name=kopiabackup
  Containers:
   kopiaexecutor:
    Image:      sivaportworx/kopiaexecutor:latest
    Port:       <none>
    Host Port:  <none>
    Command:
      /bin/sh
      -x
      -c
      /kopiaexecutor maintenance --cred-secret-name siva14-32dbaa4 --cred-secret-namespace px-backup
    Limits:
      cpu:     2
      memory:  1Gi
    Requests:
      cpu:        1
      memory:     700Mi
    Environment:  <none>
    Mounts:
      /etc/cred-secret from cred-secret (ro)
  Volumes:
   cred-secret:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  siva14-32dbaa4
    Optional:    false
Events:
  Type    Reason            Age    From            Message
  ----    ------            ----   ----            -------
  Normal  SuccessfulCreate  3m14s  job-controller  Created pod: repo-maintenance-siva14-1631709900-rt659
  Normal  Completed         77s    job-controller  Job completed
[root@central-muck-dog-0 ~]#
```
