### PR TITLE
 pb-1896: added jobname to be part of job option.

### DIFF
--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -43,7 +43,7 @@ func (d Driver) StartJob(opts ...drivers.JobOption) (id string, err error) {
 		logrus.Infof("%s %v", fn, errMsg)
 		return "", fmt.Errorf(errMsg)
 	}
-	jobName := toJobName(o.SnapshotID)
+	jobName := toJobName(o.JobName, o.SnapshotID)
 	job, err := buildJob(jobName, o)
 	if err != nil {
 		errMsg := fmt.Sprintf("building backup snapshot delete job [%s] failed: %v", jobName, err)
@@ -197,7 +197,10 @@ func jobFor(
 	}, nil
 }
 
-func toJobName(snapshotID string) string {
+func toJobName(jobName, snapshotID string) string {
+	if jobName != "" {
+		return jobName
+	}
 	return fmt.Sprintf("%s-%s", kopiaDeleteJobPrefix, snapshotID)
 }
 

--- a/pkg/drivers/kopiamaintenance/kopiamaintenance.go
+++ b/pkg/drivers/kopiamaintenance/kopiamaintenance.go
@@ -48,7 +48,7 @@ func (d Driver) StartJob(opts ...drivers.JobOption) (id string, err error) {
 		logrus.Infof("%s %v", fn, errMsg)
 		return "", fmt.Errorf(errMsg)
 	}
-	jobName := toJobName(o.BackupLocationName)
+	jobName := toJobName(o.JobName, o.BackupLocationName)
 	job, err := buildJob(jobName, o)
 	if err != nil {
 		errMsg := fmt.Sprintf("building maintenance job [%s] for backuplocation [%v] failed: %v", jobName, o.BackupLocationName, err)
@@ -196,7 +196,10 @@ func jobFor(
 	}, nil
 }
 
-func toJobName(backupLocation string) string {
+func toJobName(jobName, backupLocation string) string {
+	if jobName != "" {
+		return jobName
+	}
 	return fmt.Sprintf("%s-%s", kopiaMaintenanceJobPrefix, backupLocation)
 }
 

--- a/pkg/drivers/options.go
+++ b/pkg/drivers/options.go
@@ -21,7 +21,16 @@ type JobOpts struct {
 	SnapshotID              string
 	CredSecretName          string
 	CredSecretNamespace     string
+	JobName                 string
 	Labels                  map[string]string
+}
+
+// WithJobName is job parameter.
+func WithJobName(name string) JobOption {
+	return func(opts *JobOpts) error {
+		opts.JobName = strings.TrimSpace(name)
+		return nil
+	}
 }
 
 // WithSnapshotID is job parameter.


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-1896: added jobname to be part of job option.

            - Using jobName provided by caller, if provided for delete and
              maintenance job.
            - If not provided, taking default value.
 ```
**Which issue(s) this PR fixes** (optional)
Closes # PB-1896

**Special notes for your reviewer**:

