### PR TITLE
  pb-1915: added status reason for the repo maintenance, in the case of failure.

### DIFF
--- a/pkg/apis/kdmp/v1alpha1/backuplocationmaintenance.go
+++ b/pkg/apis/kdmp/v1alpha1/backuplocationmaintenance.go
@@ -62,4 +62,6 @@ type RepoMaintenanceStatus struct {
 	LastRunTimestamp metav1.Time `json:"lastRunTimestamp"`
 	// Status - last maintenance run status
 	Status RepoMaintenanceStatusType `json:"status"`
+	// Reason - Failure reason. In case of success it will be empty.
+	Reason string `json:"reason"`
 }

--- a/pkg/executor/kopia/restore.go
+++ b/pkg/executor/kopia/restore.go
@@ -66,6 +66,14 @@ func runRestore(snapshotID, targetPath string) error {
 	repo.Name = kopiaRepo
 
 	if err = runKopiaRepositoryConnect(repo); err != nil {
+		status := &executor.Status{
+			LastKnownError: err,
+		}
+		if err = executor.WriteVolumeBackupStatus(status, volumeBackupName, bkpNamespace); err != nil {
+			errMsg := fmt.Sprintf("failed to write a VolumeBackup status: %v", err)
+			logrus.Errorf("%v", errMsg)
+			return fmt.Errorf(errMsg)
+		}
 		errMsg := fmt.Sprintf("repository %s connect failed: %v", repo.Name, err)
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return fmt.Errorf(errMsg)

--- a/pkg/kopia/connect.go
+++ b/pkg/kopia/connect.go
@@ -67,7 +67,7 @@ func (b *connectExecutor) Run() error {
 		err := b.execCmd.Wait()
 
 		if err != nil {
-			b.lastError = fmt.Errorf("failed to run the kopia connect command: %v", err)
+			b.lastError = fmt.Errorf("failed to run the kopia connect command: %v", b.execCmd.Stderr)
 			logrus.Errorf("%v", b.lastError)
 			logrus.Debugf("stdout: %v", b.execCmd.Stdout)
 			logrus.Debugf("stderr: %v", b.execCmd.Stderr)

--- a/pkg/kopia/maintenancerun.go
+++ b/pkg/kopia/maintenancerun.go
@@ -49,7 +49,7 @@ func (mr *maintenanceRunExecutor) Run() error {
 	go func() {
 		err := mr.execCmd.Wait()
 		if err != nil {
-			mr.lastError = fmt.Errorf("failed to run the repo maintenance command: %v", err)
+			mr.lastError = fmt.Errorf("failed to run the repo maintenance command: %v", mr.execCmd.Stderr)
 			logrus.Infof("stdout: %v", mr.execCmd.Stdout)
 			logrus.Infof("Stderr: %v", mr.execCmd.Stderr)
 		}

--- a/pkg/kopia/maintenanceset.go
+++ b/pkg/kopia/maintenanceset.go
@@ -62,7 +62,7 @@ func (ms *maintenanceSetExecutor) Run() error {
 	go func() {
 		err := ms.execCmd.Wait()
 		if err != nil {
-			ms.lastError = fmt.Errorf("failed to run the repo maintenance set command: %v", err)
+			ms.lastError = fmt.Errorf("failed to run the repo maintenance set command: %v", ms.execCmd.Stderr)
 			logrus.Infof("stdout: %v", ms.execCmd.Stdout)
 			logrus.Infof("Stderr: %v", ms.execCmd.Stderr)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
```
  pb-1915: added status reason for the repo maintenance, in the case of
    failure.

        - if one of the repo maintenance fails, Continuing with the other repos in the backuplocation.
        - Removed the step to update the volumeBackup CR from
          runKopiaRepositoryConnect as it is used by delete and
          maintenace command as well.
```
          
**Which issue(s) this PR fixes** (optional)
Closes # Pb-1915

**Special notes for your reviewer**:
**Testing:**
Set the incorrect for the repo connect for testing purpose and maintenance failed in connect and checked that reason is update with error message from kopia command.
```
[root@central-muck-dog-0 ~]# kubectl describe backuplocationmaintenance repo-maintenance-location2-f036c4f -n px-backup
Name:         repo-maintenance-location2-f036c4f
Namespace:    px-backup
Labels:       <none>
Annotations:  <none>
API Version:  kdmp.portworx.com/v1alpha1
Kind:         BackupLocationMaintenance
Metadata:
  Creation Timestamp:  2021-09-25T10:26:22Z
  Generation:          81
  Managed Fields:
    API Version:  kdmp.portworx.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:BackuplocationName:
        f:CredSecret:
      f:status:
        .:
        f:RepoStatus:
    Manager:      px-backup
    Operation:    Update
    Time:         2021-09-25T10:26:22Z
    API Version:  kdmp.portworx.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:RepoStatus:
          f:generic-backup/px-backup-pxc-mongodb-data-pxc-backup-mongodb-0/:
            .:
            f:Reason:
            f:lastRunTimestamp:
            f:status:
          f:generic-backup/px-backup-pxc-mongodb-data-pxc-backup-mongodb-1/:
            .:
            f:Reason:
            f:lastRunTimestamp:
            f:status:
          f:generic-backup/px-backup-pxc-mongodb-data-pxc-backup-mongodb-2/:
            .:
            f:Reason:
            f:lastRunTimestamp:
            f:status:
          f:generic-backup/px-backup-pxcentral-keycloak-data-pxcentral-keycloak-postgresql-0/:
            .:
            f:Reason:
            f:lastRunTimestamp:
            f:status:
          f:generic-backup/px-backup-pxcentral-mysql-pvc/:
            .:
            f:Reason:
            f:lastRunTimestamp:
            f:status:
          f:generic-backup/px-backup-theme-pxcentral-keycloak-0/:
            .:
            f:Reason:
            f:lastRunTimestamp:
            f:status:
    Manager:         kopiaexecutor
    Operation:       Update
    Time:            2021-09-25T11:22:44Z
  Resource Version:  11380147
  Self Link:         /apis/kdmp.portworx.com/v1alpha1/namespaces/px-backup/backuplocationmaintenances/repo-maintenance-location2-f036c4f
  UID:               661ead79-7b85-4566-9dac-834bccafd67a
Spec:
  Backuplocation Name:  location2
  Cred Secret:          repo-maintenance-location2-f036c4f
Status:
  Repo Status:
    generic-backup/px-backup-pxc-mongodb-data-pxc-backup-mongodb-0/:
      Reason:  failed to run the kopia connect command: failed to open repository: invalid repository password
kopia: error: error connecting to repository: invalid repository password, try --help

      Last Run Timestamp:  2021-09-25T11:22:18Z
      Status:              Failed
    generic-backup/px-backup-pxc-mongodb-data-pxc-backup-mongodb-1/:
      Reason:  failed to run the kopia connect command: failed to open repository: invalid repository password
kopia: error: error connecting to repository: invalid repository password, try --help

      Last Run Timestamp:  2021-09-25T11:22:23Z
      Status:              Failed
    generic-backup/px-backup-pxc-mongodb-data-pxc-backup-mongodb-2/:
      Reason:  failed to run the kopia connect command: failed to open repository: invalid repository password
kopia: error: error connecting to repository: invalid repository password, try --help

      Last Run Timestamp:  2021-09-25T11:22:28Z
      Status:              Failed
    generic-backup/px-backup-pxcentral-keycloak-data-pxcentral-keycloak-postgresql-0/:
      Reason:  failed to run the kopia connect command: failed to open repository: invalid repository password
kopia: error: error connecting to repository: invalid repository password, try --help

      Last Run Timestamp:  2021-09-25T11:22:34Z
      Status:              Failed
    generic-backup/px-backup-pxcentral-mysql-pvc/:
      Reason:  failed to run the kopia connect command: failed to open repository: invalid repository password
kopia: error: error connecting to repository: invalid repository password, try --help

      Last Run Timestamp:  2021-09-25T11:22:39Z
      Status:              Failed
    generic-backup/px-backup-theme-pxcentral-keycloak-0/:
      Reason:  failed to run the kopia connect command: failed to open repository: invalid repository password
kopia: error: error connecting to repository: invalid repository password, try --help

      Last Run Timestamp:  2021-09-25T11:22:44Z
      Status:              Failed
Events:                    <none>
```