### PR TITLE
pb-1917: made the executor of backup, restore, delete and maintenance executor to run for completion instead of timeout in 2 mints.

### DIFF
--- a/pkg/executor/kopia/kopiabackup.go
+++ b/pkg/executor/kopia/kopiabackup.go
@@ -257,24 +257,12 @@ func runKopiaBackup(repository *executor.Repository, sourcePath string) error {
 		return err
 	}
 
-	t := func() (interface{}, bool, error) {
+	for {
+		time.Sleep(progressCheckInterval)
 		status, err := backupExecutor.Status()
 		if err != nil {
-			return "", false, err
+			return err
 		}
-		if status.LastKnownError != nil {
-			if err = executor.WriteVolumeBackupStatus(
-				status,
-				volumeBackupName,
-				bkpNamespace,
-			); err != nil {
-				errMsg := fmt.Sprintf("failed to write a VolumeBackup status: %v", err)
-				logrus.Errorf("%v", errMsg)
-				return "", false, fmt.Errorf(errMsg)
-			}
-			return "", false, status.LastKnownError
-		}
-
 		if err = executor.WriteVolumeBackupStatus(
 			status,
 			volumeBackupName,
@@ -282,21 +270,17 @@ func runKopiaBackup(repository *executor.Repository, sourcePath string) error {
 		); err != nil {
 			errMsg := fmt.Sprintf("failed to write a VolumeBackup status: %v", err)
 			logrus.Errorf("%v", errMsg)
-			return "", false, fmt.Errorf(errMsg)
+			continue
+		}
+		if status.LastKnownError != nil {
+			return status.LastKnownError
 		}
 		if status.Done {
-			return "", false, nil
+			break
 		}
 
-		return "", true, fmt.Errorf("backup status not available")
 	}
-	if _, err := task.DoRetryWithTimeout(t, executor.DefaultTimeout, progressCheckInterval); err != nil {
-		logrus.Errorf("backup failed for repository %s: %v", repository.Name, err)
-		return err
-	}
-
 	logrus.Infof("Backup successful")
-
 	return nil
 }
 


### PR DESCRIPTION

**What this PR does / why we need it**:
pb-1917: made the executor of backup, restore, delete and maintenance executor to run for completion instead of timeout in 2 mints.
**Which issue(s) this PR fixes** (optional)
Closes # PB-1917

**Special notes for your reviewer**:

