### PR TITLE
PB-1914: Adding supporting for enabling/disabling ssl for kopia connections

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 
 	"github.com/aquilax/truncate"
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
@@ -762,6 +763,7 @@ func createS3Secret(secretName string, backupLocation *storkapi.BackupLocation, 
 	credentialData["path"] = []byte(backupLocation.Location.Path)
 	credentialData["type"] = []byte(backupLocation.Location.Type)
 	credentialData["password"] = []byte(backupLocation.Location.RepositoryPassword)
+	credentialData["disablessl"] = []byte(strconv.FormatBool(backupLocation.Location.S3Config.DisableSSL))
 	err := createCredSecret(secretName, namespace, credentialData)
 
 	return err

--- a/pkg/executor/kopia/kopiabackup.go
+++ b/pkg/executor/kopia/kopiabackup.go
@@ -101,7 +101,6 @@ func runBackup(sourcePath string) error {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return fmt.Errorf("%s: %v", errMsg, err)
 	}
-
 	if !exists {
 		if err = runKopiaCreateRepo(repo); err != nil {
 			errMsg := fmt.Sprintf("repository %s creation failed", repo.Name)
@@ -171,7 +170,13 @@ func populateAzureccessDetails(initCmd *kopia.Command, repository *executor.Repo
 
 func runKopiaCreateRepo(repository *executor.Repository) error {
 	logrus.Infof("Repository creation started")
-	repoCreateCmd, err := kopia.GetCreateCommand(repository.Path, repository.Name, repository.Password, string(repository.Type))
+	repoCreateCmd, err := kopia.GetCreateCommand(
+		repository.Path,
+		repository.Name,
+		repository.Password,
+		string(repository.Type),
+		repository.S3Config.DisableSSL,
+	)
 	if err != nil {
 		return err
 	}
@@ -302,7 +307,13 @@ func runKopiaBackup(repository *executor.Repository, sourcePath string) error {
 
 func runKopiaRepositoryConnect(repository *executor.Repository) error {
 	logrus.Infof("Repository connect started")
-	connectCmd, err := kopia.GetConnectCommand(repository.Path, repository.Name, repository.Password, string(repository.Type))
+	connectCmd, err := kopia.GetConnectCommand(
+		repository.Path,
+		repository.Name,
+		repository.Password,
+		string(repository.Type),
+		repository.S3Config.DisableSSL,
+	)
 	if err != nil {
 		return err
 	}
@@ -416,6 +427,7 @@ func buildStorkBackupLocation(repository *executor.Repository) (*storkv1.BackupL
 			SecretAccessKey: repository.S3Config.SecretAccessKey,
 			Endpoint:        repository.S3Config.Endpoint,
 			Region:          repository.S3Config.Region,
+			DisableSSL:      repository.S3Config.DisableSSL,
 		}
 	case storkv1.BackupLocationGoogle:
 		backupType = storkv1.BackupLocationGoogle

--- a/pkg/kopia/command.go
+++ b/pkg/kopia/command.go
@@ -38,6 +38,8 @@ type Command struct {
 	SnapshotID string
 	// MaintenanceOwner owner of maintenance command
 	MaintenanceOwner string
+	// DisableSsl option to disable ssl for s3
+	DisableSsl bool
 }
 
 // Executor interface defines APIs for implementing a command wrapper
@@ -98,7 +100,13 @@ func (c *Command) CreateCmd() *exec.Cmd {
 			c.RepositoryName,
 		}
 	}
-
+	var ssl []string
+	if c.DisableSsl {
+		ssl = []string{
+			"--disable-tls",
+		}
+	}
+	argsSlice = append(argsSlice, ssl...)
 	argsSlice = append(argsSlice, c.Flags...)
 	// Get the cmd args
 	argsSlice = append(argsSlice, c.Args...)
@@ -157,8 +165,14 @@ func (c *Command) ConnectCmd() *exec.Cmd {
 			c.RepositoryName,
 		}
 	}
-
+	var ssl []string
+	if c.DisableSsl {
+		ssl = []string{
+			"--disable-tls",
+		}
+	}
 	argsSlice = append(argsSlice, c.Flags...)
+	argsSlice = append(argsSlice, ssl...)
 	// Get the cmd args
 	argsSlice = append(argsSlice, c.Args...)
 	cmd := exec.Command(baseCmd, argsSlice...)
@@ -166,7 +180,6 @@ func (c *Command) ConnectCmd() *exec.Cmd {
 		cmd.Env = append(os.Environ(), c.Env...)
 	}
 	cmd.Dir = c.Dir
-
 	return cmd
 }
 

--- a/pkg/kopia/connect.go
+++ b/pkg/kopia/connect.go
@@ -30,7 +30,7 @@ const (
 )
 
 // GetConnectCommand returns a wrapper over the kopia connect command
-func GetConnectCommand(path, repoName, password, provider string) (*Command, error) {
+func GetConnectCommand(path, repoName, password, provider string, disableSsl bool) (*Command, error) {
 	if repoName == "" {
 		return nil, fmt.Errorf("repository name cannot be empty")
 	}
@@ -40,6 +40,7 @@ func GetConnectCommand(path, repoName, password, provider string) (*Command, err
 		RepositoryName: repoName,
 		Password:       password,
 		Path:           path,
+		DisableSsl:     disableSsl,
 	}, nil
 }
 

--- a/pkg/kopia/create.go
+++ b/pkg/kopia/create.go
@@ -35,7 +35,7 @@ type createExecutor struct {
 }
 
 // GetCreateCommand returns a wrapper over the kopia repo create command
-func GetCreateCommand(path, repoName, password, provider string) (*Command, error) {
+func GetCreateCommand(path, repoName, password, provider string, disableSsl bool) (*Command, error) {
 	if repoName == "" {
 		return nil, fmt.Errorf("repository name cannot be empty")
 	}
@@ -45,6 +45,7 @@ func GetCreateCommand(path, repoName, password, provider string) (*Command, erro
 		RepositoryName: repoName,
 		Password:       password,
 		Path:           path,
+		DisableSsl:     disableSsl,
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding support for enabling/disabling ssl for kopia connections

**Which issue(s) this PR fixes** (optional)
PB-1914

**Special notes for your reviewer**:
None

**Manual test**
Tested using spinning up a local minio without https

1. Have the following CR created with `disablessl: true` 
```
# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
apiVersion: stork.libopenstorage.org/v1alpha1
kind: BackupLocation
location:
  path: test-bucket
  repositoryPassword: k0p1@#GB
  s3Config:
    accessKeyID: minioadmin
    disableSSL: true
    endpoint: 70.0.114.169:9000
    region: us-east-1
    secretAccessKey: minioadmin
  type: s3
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"stork.libopenstorage.org/v1alpha1","kind":"BackupLocation","location":{"path":"test-bucket","repositoryP
assword":"k0p1@#GB","s3Config":{"accessKeyID":"minioadmin","disableSSL":true,"endpoint":"70.0.114.169:9000","region":"us-east
-1","secretAccessKey":"minioadmin"},"type":"s3"},"metadata":{"annotations":{"stork.libopenstorage.org/skipresource":"true"},"
name":"local-minio-bl","namespace":"rst"}}
    stork.libopenstorage.org/skipresource: "true"
  creationTimestamp: "2021-09-26T18:23:21Z"
  generation: 5
  name: local-minio-bl
  namespace: rst
  resourceVersion: "32977813"
  uid: 2541edda-1772-470c-a63f-6d5e8e926efb
```

2. Now start a generic backup, would fail as server is sending http response
``` 
[root@prashanth-iron-seer-0 kdmp]# k logs b-kopia-aws-mysql-1-4gkqf -nrst
+ /kopiaexecutor backup --volume-backup-name b-kopia-aws-mysql-1 --credentials b-kopia-aws-mysql-1 --backup-location local-mc
time="2021-09-27T17:08:17Z" level=info msg="line 328 ParseCloudCred"
time="2021-09-27T17:08:17Z" level=info msg="type: s3"
time="2021-09-27T17:08:17Z" level=info msg="line 328 repository.S3Config: &{70.0.114.169:9000 minioadmin minioadmin us-east-"
time="2021-09-27T17:08:17Z" level=error msg="blob (key \"kopia.repository\") (code=Unknown): RequestError: send request fail"
time="2021-09-27T17:08:17Z" level=error msg="runBackup: repository exists check for repo generic-backup/rst-mysql-data/ fail"
error: repository exists check for repo generic-backup/rst-mysql-data/ failed: blob (key "kopia.repository") (code=Unknown):d
caused by: Head "https://70.0.114.169:9000/test-bucket/generic-backup/rst-mysql-data/kopia.repository": http: server gave HTd
caused by: Head "https://70.0.114.169:9000/test-bucket/generic-backup/rst-mysql-data/kopia.repository": http: server gave HTt
[root@prashanth-iron-seer-0 kdmp]#
[ prashanth-iron-seer-0 ][  (0*!$root@prashanth-ir
```

3. Now with the fix
```

  [root@prashanth-iron-seer-0 kdmp]# k logs -f b-kopia-aws-mysql-1-vmw5l -nrst
+ /kopiaexecutor backup --volume-backup-name b-kopia-aws-mysql-1 --credentials b-kopia-aws-mysql-1 --backup-location local-mc
time="2021-09-27T17:06:57Z" level=info msg="line 328 ParseCloudCred"
time="2021-09-27T17:06:57Z" level=info msg="type: s3"
time="2021-09-27T17:06:57Z" level=info msg="line 328 repository.S3Config: &{70.0.114.169:9000 minioadmin minioadmin us-east-"
time="2021-09-27T17:06:57Z" level=info msg="kopia.repository exists"
time="2021-09-27T17:06:57Z" level=info msg="line 104 runBackup"
time="2021-09-27T17:06:57Z" level=info msg="Repository connect started"
time="2021-09-27T17:06:57Z" level=info msg="line 186 cmd: /usr/bin/kopia repository connect s3 --bucket test-bucket --passwo"
2021/09/27 17:06:57 repository connect status not available Next retry in: 5s
time="2021-09-27T17:07:02Z" level=info msg="kopia repo connect successful .."
time="2021-09-27T17:07:02Z" level=info msg="Backup started"
2021/09/27 17:07:02 backup status not available Next retry in: 5s
time="2021-09-27T17:07:07Z" level=info msg="Backup successful"
[root@prashanth-iron-seer-0 kdmp]#
```