### PR TITLE
PB-1921: Add support for passing custom certificates

### DIFF
--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -39,6 +39,10 @@ const (
 	KopiaSecretMount     = "/tmp/kopiasecret"
 	KopiaSecretKey       = "password"
 	KopiaCredSecretMount = "/etc/cred-secret"
+	CertDirPath          = "SSL_CERT_DIR"
+	CertFileName         = "public.crt"
+	CertSecretName       = "tls-s3-cert"
+	CertMount            = "/etc/tls-s3-cert"
 )
 
 // Driver job options.
@@ -71,6 +75,11 @@ const (
 	DefaultResticExecutorRequestMemory = "700Mi"
 	DefaultResticExecutorLimitCPU      = "2"
 	DefaultResticExecutorLimitMemory   = "1Gi"
+)
+
+var (
+	// CertFilePath path where certificates are mounted in the pod for TLS
+	CertFilePath string
 )
 
 // JobState represents a data transfer job state.

--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -136,18 +136,14 @@ func (d Driver) validate(o drivers.JobOpts) error {
 }
 
 func jobFor(
+	jobOption drivers.JobOpts,
 	jobName,
-	namespace,
-	pvcName,
-	credSecretName,
-	backuplocationName,
-	backuplocationNamespace,
-	backupNamespace string,
+	credSecretName string,
 	resources corev1.ResourceRequirements,
-	labels map[string]string) (*batchv1.Job, error) {
+) (*batchv1.Job, error) {
 	backupName := jobName
 
-	labels = addJobLabels(labels)
+	labels := addJobLabels(jobOption.Labels)
 
 	cmd := strings.Join([]string{
 		"/kopiaexecutor",
@@ -155,23 +151,23 @@ func jobFor(
 		"--volume-backup-name",
 		backupName,
 		"--repository",
-		toRepoName(pvcName, namespace),
+		toRepoName(jobOption.SourcePVCName, jobOption.Namespace),
 		"--credentials",
 		credSecretName,
 		"--backup-location",
-		backuplocationName,
+		jobOption.BackupLocationName,
 		"--backup-location-namespace",
-		backuplocationNamespace,
+		jobOption.BackupLocationNamespace,
 		"--backup-namespace",
-		backupNamespace,
+		jobOption.Namespace,
 		"--source-path",
 		"/data",
 	}, " ")
 
-	return &batchv1.Job{
+	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
-			Namespace: namespace,
+			Namespace: jobOption.Namespace,
 			Labels:    labels,
 		},
 		Spec: batchv1.JobSpec{
@@ -187,7 +183,7 @@ func jobFor(
 						{
 							Name:            "kopiaexecutor",
 							Image:           utils.KopiaExecutorImage(),
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							ImagePullPolicy: corev1.PullAlways,
 							Command: []string{
 								"/bin/sh",
 								"-x",
@@ -213,7 +209,7 @@ func jobFor(
 							Name: "vol",
 							VolumeSource: corev1.VolumeSource{
 								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: pvcName,
+									ClaimName: jobOption.SourcePVCName,
 								},
 							},
 						},
@@ -229,7 +225,42 @@ func jobFor(
 				},
 			},
 		},
-	}, nil
+	}
+
+	if drivers.CertFilePath != "" {
+		volumeMount := corev1.VolumeMount{
+			Name:      "tls-secret",
+			MountPath: drivers.CertMount,
+			ReadOnly:  true,
+		}
+
+		job.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+			job.Spec.Template.Spec.Containers[0].VolumeMounts,
+			volumeMount,
+		)
+
+		volume := corev1.Volume{
+			Name: "tls-secret",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: jobOption.CertSecretName,
+				},
+			},
+		}
+
+		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, volume)
+
+		env := []corev1.EnvVar{
+			{
+				Name:  drivers.CertDirPath,
+				Value: drivers.CertMount,
+			},
+		}
+
+		job.Spec.Template.Spec.Containers[0].Env = env
+	}
+
+	return job, nil
 }
 
 func toJobName(sourcePVCName string) string {
@@ -249,21 +280,21 @@ func addJobLabels(labels map[string]string) map[string]string {
 	return labels
 }
 
-func buildJob(jobName string, o drivers.JobOpts) (*batchv1.Job, error) {
+func buildJob(jobName string, jobOptions drivers.JobOpts) (*batchv1.Job, error) {
 	fn := "buildJob"
 	resources, err := utils.JobResourceRequirements()
 	if err != nil {
 		return nil, err
 	}
-	if err := utils.SetupServiceAccount(jobName, o.Namespace, roleFor()); err != nil {
-		errMsg := fmt.Sprintf("error creating service account %s/%s: %v", o.Namespace, jobName, err)
+	if err := utils.SetupServiceAccount(jobName, jobOptions.Namespace, roleFor()); err != nil {
+		errMsg := fmt.Sprintf("error creating service account %s/%s: %v", jobOptions.Namespace, jobName, err)
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
 
-	pods, err := coreops.Instance().GetPodsUsingPVC(o.SourcePVCName, o.Namespace)
+	pods, err := coreops.Instance().GetPodsUsingPVC(jobOptions.SourcePVCName, jobOptions.Namespace)
 	if err != nil {
-		errMsg := fmt.Sprintf("error fetching pods using PVC %s/%s: %v", o.Namespace, o.SourcePVCName, err)
+		errMsg := fmt.Sprintf("error fetching pods using PVC %s/%s: %v", jobOptions.Namespace, jobOptions.SourcePVCName, err)
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
@@ -271,29 +302,19 @@ func buildJob(jobName string, o drivers.JobOpts) (*batchv1.Job, error) {
 	// run a "live" backup if a pvc is mounted (mount a kubelet directory with pod volumes)
 	if len(pods) > 0 {
 		return jobForLiveBackup(
+			jobOptions,
 			jobName,
-			o.Namespace,
-			o.SourcePVCName,
-			utils.FrameCredSecretName(utils.BackupJobPrefix, o.DataExportName),
-			o.BackupLocationName,
-			o.BackupLocationNamespace,
-			o.Namespace,
+			utils.FrameCredSecretName(utils.BackupJobPrefix, jobOptions.DataExportName),
 			pods[0],
 			resources,
-			o.Labels,
 		)
 	}
 
 	return jobFor(
+		jobOptions,
 		jobName,
-		o.Namespace,
-		o.SourcePVCName,
-		utils.FrameCredSecretName(utils.BackupJobPrefix, o.DataExportName),
-		o.BackupLocationName,
-		o.BackupLocationNamespace,
-		o.Namespace,
+		utils.FrameCredSecretName(utils.BackupJobPrefix, jobOptions.DataExportName),
 		resources,
-		o.Labels,
 	)
 }
 

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
 	"github.com/portworx/kdmp/pkg/drivers"
 	"github.com/portworx/kdmp/pkg/drivers/utils"
 	kdmpops "github.com/portworx/kdmp/pkg/util/ops"
@@ -46,17 +47,12 @@ func (d Driver) StartJob(opts ...drivers.JobOption) (id string, err error) {
 
 	jobName := toJobName(o.DestinationPVCName)
 	job, err := jobFor(
+		o,
+		vb,
 		jobName,
-		o.Namespace,
-		o.DestinationPVCName,
-		o.VolumeBackupName,
 		utils.FrameCredSecretName(utils.RestoreJobPrefix, o.DataExportName),
-		vb.Spec.BackupLocation.Name,
-		vb.Spec.BackupLocation.Namespace,
-		o.Namespace,
-		vb.Status.SnapshotID,
-		vb.Spec.Repository,
-		o.Labels)
+		o.Labels,
+	)
 	if err != nil {
 		return "", err
 	}
@@ -126,17 +122,12 @@ func (d Driver) validate(o drivers.JobOpts) error {
 }
 
 func jobFor(
+	jobOption drivers.JobOpts,
+	vb *v1alpha1.VolumeBackup,
 	jobName,
-	namespace,
-	pvcName,
-	volumeBackupName,
-	credSecretName,
-	backuplocationName,
-	backuplocationNamespace,
-	restoreNamespace,
-	snapshotID,
-	repository string,
-	labels map[string]string) (*batchv1.Job, error) {
+	credSecretName string,
+	labels map[string]string,
+) (*batchv1.Job, error) {
 	labels = addJobLabels(labels)
 
 	resources, err := utils.JobResourceRequirements()
@@ -144,7 +135,7 @@ func jobFor(
 		return nil, err
 	}
 
-	if err := utils.SetupServiceAccount(jobName, namespace, roleFor()); err != nil {
+	if err := utils.SetupServiceAccount(jobName, jobOption.Namespace, roleFor()); err != nil {
 		return nil, err
 	}
 
@@ -152,27 +143,27 @@ func jobFor(
 		"/kopiaexecutor",
 		"restore",
 		"--volume-backup-name",
-		volumeBackupName,
+		jobOption.VolumeBackupName,
 		"--backup-location",
-		backuplocationName,
+		vb.Spec.BackupLocation.Name,
 		"--backup-location-namespace",
-		backuplocationNamespace,
+		vb.Spec.BackupLocation.Namespace,
 		"--repository",
-		repository,
+		vb.Spec.Repository,
 		"--restore-namespace",
-		restoreNamespace,
+		jobOption.Namespace,
 		"--credentials",
 		credSecretName,
 		"--target-path",
 		"/data",
 		"--snapshot-id",
-		snapshotID,
+		vb.Status.SnapshotID,
 	}, " ")
 
-	return &batchv1.Job{
+	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
-			Namespace: namespace,
+			Namespace: jobOption.Namespace,
 			Labels:    labels,
 		},
 		Spec: batchv1.JobSpec{
@@ -214,7 +205,7 @@ func jobFor(
 							Name: "vol",
 							VolumeSource: corev1.VolumeSource{
 								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: pvcName,
+									ClaimName: jobOption.DestinationPVCName,
 								},
 							},
 						},
@@ -230,7 +221,42 @@ func jobFor(
 				},
 			},
 		},
-	}, nil
+	}
+
+	if drivers.CertFilePath != "" {
+		volumeMount := corev1.VolumeMount{
+			Name:      "tls-secret",
+			MountPath: drivers.CertMount,
+			ReadOnly:  true,
+		}
+
+		job.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+			job.Spec.Template.Spec.Containers[0].VolumeMounts,
+			volumeMount,
+		)
+
+		volume := corev1.Volume{
+			Name: "tls-secret",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: jobOption.CertSecretName,
+				},
+			},
+		}
+
+		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, volume)
+
+		env := []corev1.EnvVar{
+			{
+				Name:  drivers.CertDirPath,
+				Value: drivers.CertMount,
+			},
+		}
+
+		job.Spec.Template.Spec.Containers[0].Env = env
+	}
+
+	return job, nil
 }
 
 func toJobName(destinationPVC string) string {

--- a/pkg/drivers/options.go
+++ b/pkg/drivers/options.go
@@ -32,6 +32,8 @@ type JobOpts struct {
 	BackupObjectName            string
 	BackupObjectUID             string
 	Labels                      map[string]string
+	CertSecretName              string
+	CertSecretNamespace         string
 }
 
 // WithBackupObjectName is job parameter.
@@ -269,6 +271,22 @@ func WithDataExportName(name string) JobOption {
 			return fmt.Errorf("dataexport namespace should be set")
 		}
 		opts.DataExportName = name
+		return nil
+	}
+}
+
+// WithCertSecretName is job parameter.
+func WithCertSecretName(name string) JobOption {
+	return func(opts *JobOpts) error {
+		opts.CertSecretName = name
+		return nil
+	}
+}
+
+// WithCertSecretNamespace is job parameter.
+func WithCertSecretNamespace(namespace string) JobOption {
+	return func(opts *JobOpts) error {
+		opts.CertSecretNamespace = namespace
 		return nil
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add supprot for passing custom certificates
- User creates secret out of public certificate, mounts to controller pod
- Provide certificate path in env SSL_CERT_DIR so job pods can pick and
  mount the certificate as part of jobs


**Which issue(s) this PR fixes** (optional)
PB-1921

**Special notes for your reviewer**:

Manual test
1. Deployed minio locally with self-signed certificates
2. Mounted the certificate as the secret to stork under kube-system ns
3. Add the following to the stork deployment spec
```
  - name: SSL_CERT_DIR
          value: "/etc/tls-secrets"

volumeMounts:
        - name: tls-secrets
          mountPath: "/etc/tls-secrets"
          readOnly: true

volumes:
      - name: tls-secrets
        secret:
          secretName: tls-s3-certs
```

4. Trigerred a generic backup/restore on proxy vol which was successful
5. 