### PR TITLE
pb-1941: Changed the name format for all the kdmp generic backup resource.

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -8,10 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
-
 	"strings"
-
-	"github.com/aquilax/truncate"
 
 	kSnapshotClient "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
@@ -145,7 +142,7 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 
 		// Check if the above env is present and read the certs file contents and
 		// secret for the job pod for kopia to access the same
-		err = createCertificateSecret(drivers.CertSecretName, dataExport.Spec.Source.Namespace)
+		err = createCertificateSecret(drivers.CertSecretName, dataExport.Spec.Source.Namespace, dataExport.Labels)
 		if err != nil {
 			return false, err
 		}
@@ -154,10 +151,11 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 			// Create secret in source ns because in case of multi ns backup
 			// BL CR is created in kube-system ns
 			err = CreateCredentialsSecret(
-				utils.FrameCredSecretName(utils.BackupJobPrefix, dataExport.Name),
+				dataExport.Name,
 				dataExport.Spec.Destination.Name,
 				dataExport.Spec.Destination.Namespace,
 				dataExport.Spec.Source.Namespace,
+				dataExport.Labels,
 			)
 			if err != nil {
 				msg := fmt.Sprintf("failed to create cloud credential secret during kopia backup: %v", err)
@@ -181,10 +179,11 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 			// For restore create the secret in the ns where PVC is referenced
 
 			err = CreateCredentialsSecret(
-				utils.FrameCredSecretName(utils.RestoreJobPrefix, dataExport.Name),
+				dataExport.Name,
 				vb.Spec.BackupLocation.Name,
 				vb.Spec.BackupLocation.Namespace,
 				dataExport.Spec.Destination.Namespace,
+				dataExport.Labels,
 			)
 			if err != nil {
 				msg := fmt.Sprintf("failed to create cloud credential secret during kopia restore: %v", err)
@@ -659,7 +658,7 @@ func startTransferJob(drv drivers.Interface, srcPVCName string, dataExport *kdmp
 			drivers.WithSourcePVC(srcPVCName),
 			drivers.WithNamespace(dataExport.Spec.Destination.Namespace),
 			drivers.WithDestinationPVC(dataExport.Spec.Destination.Name),
-			drivers.WithLabels(jobLabels(dataExport)),
+			drivers.WithLabels(dataExport.Labels),
 		)
 	case drivers.ResticBackup:
 		return drv.StartJob(
@@ -667,7 +666,7 @@ func startTransferJob(drv drivers.Interface, srcPVCName string, dataExport *kdmp
 			drivers.WithNamespace(dataExport.Spec.Destination.Namespace),
 			drivers.WithBackupLocationName(dataExport.Spec.Destination.Name),
 			drivers.WithBackupLocationNamespace(dataExport.Spec.Destination.Namespace),
-			drivers.WithLabels(jobLabels(dataExport)),
+			drivers.WithLabels(dataExport.Labels),
 		)
 	case drivers.ResticRestore:
 		return drv.StartJob(
@@ -676,7 +675,7 @@ func startTransferJob(drv drivers.Interface, srcPVCName string, dataExport *kdmp
 			drivers.WithNamespace(dataExport.Spec.Source.Namespace),
 			drivers.WithVolumeBackupName(dataExport.Spec.Source.Name),
 			drivers.WithVolumeBackupNamespace(dataExport.Spec.Source.Namespace),
-			drivers.WithLabels(jobLabels(dataExport)),
+			drivers.WithLabels(dataExport.Labels),
 		)
 	case drivers.KopiaBackup:
 		return drv.StartJob(
@@ -684,7 +683,7 @@ func startTransferJob(drv drivers.Interface, srcPVCName string, dataExport *kdmp
 			drivers.WithNamespace(dataExport.Spec.Source.Namespace),
 			drivers.WithBackupLocationName(dataExport.Spec.Destination.Name),
 			drivers.WithBackupLocationNamespace(dataExport.Spec.Destination.Namespace),
-			drivers.WithLabels(jobLabels(dataExport)),
+			drivers.WithLabels(dataExport.Labels),
 			drivers.WithDataExportName(dataExport.GetName()),
 			drivers.WithCertSecretName(drivers.CertSecretName),
 			drivers.WithCertSecretNamespace(dataExport.Spec.Source.Namespace),
@@ -696,7 +695,7 @@ func startTransferJob(drv drivers.Interface, srcPVCName string, dataExport *kdmp
 			drivers.WithVolumeBackupName(dataExport.Spec.Source.Name),
 			drivers.WithVolumeBackupNamespace(dataExport.Spec.Source.Namespace),
 			drivers.WithBackupLocationNamespace(dataExport.Spec.Source.Namespace),
-			drivers.WithLabels(jobLabels(dataExport)),
+			drivers.WithLabels(dataExport.Labels),
 			drivers.WithDataExportName(dataExport.GetName()),
 			drivers.WithCertSecretName(drivers.CertSecretName),
 			drivers.WithCertSecretNamespace(dataExport.Spec.Destination.Namespace),
@@ -765,35 +764,6 @@ func setStatus(de *kdmpapi.DataExport, status kdmpapi.DataExportStatus, reason s
 
 func isStatusEqual(de *kdmpapi.DataExport, status kdmpapi.DataExportStatus, reason string) bool {
 	return de.Status.Status == status && de.Status.Reason == reason
-}
-
-func jobLabels(dataExport *kdmpapi.DataExport) map[string]string {
-	labels := make(map[string]string)
-	if len(dataExport.GetName()) <= labelNamelimit {
-		labels[LabelController] = dataExport.GetName()
-		labels[LabelControllerName] = dataExport.GetName()
-	} else {
-		// truncating it to length of labelNamelimit and store it.
-		labels[LabelController] = truncate.Truncate(dataExport.GetName(), labelNamelimit, "", truncate.PositionEnd)
-		labels[LabelControllerName] = truncate.Truncate(dataExport.GetName(), labelNamelimit, "", truncate.PositionEnd)
-	}
-
-	if val, ok := dataExport.Labels[backupCRNameKey]; ok {
-		if len(val) <= labelNamelimit {
-			labels[backupCRNameKey] = val
-		} else {
-			labels[backupCRNameKey] = truncate.Truncate(val, labelNamelimit, "", truncate.PositionEnd)
-		}
-	}
-
-	if val, ok := dataExport.Labels[pvcNameKey]; ok {
-		if len(val) < labelNamelimit {
-			labels[pvcNameKey] = val
-		} else {
-			labels[pvcNameKey] = truncate.Truncate(val, labelNamelimit, "", truncate.PositionEnd)
-		}
-	}
-	return labels
 }
 
 func getDriverType(de *kdmpapi.DataExport) (string, error) {
@@ -869,7 +839,7 @@ func checkNameNamespace(ref kdmpapi.DataExportObjectReference) error {
 }
 
 // CreateCredentialsSecret parses the provided backup location and creates secret with cloud credentials
-func CreateCredentialsSecret(secretName, blName, blNamespace, namespace string) error {
+func CreateCredentialsSecret(secretName, blName, blNamespace, namespace string, labels map[string]string) error {
 	backupLocation, err := readBackupLocation(blName, blNamespace, "")
 	if err != nil {
 		return err
@@ -879,11 +849,11 @@ func CreateCredentialsSecret(secretName, blName, blNamespace, namespace string) 
 	// Creating cloud cred secret
 	switch backupLocation.Location.Type {
 	case storkapi.BackupLocationS3:
-		return createS3Secret(secretName, backupLocation, namespace)
+		return createS3Secret(secretName, backupLocation, namespace, labels)
 	case storkapi.BackupLocationGoogle:
-		return createGoogleSecret(secretName, backupLocation, namespace)
+		return createGoogleSecret(secretName, backupLocation, namespace, labels)
 	case storkapi.BackupLocationAzure:
-		return createAzureSecret(secretName, backupLocation, namespace)
+		return createAzureSecret(secretName, backupLocation, namespace, labels)
 	}
 
 	return fmt.Errorf("unsupported backup location: %v", backupLocation.Location.Type)
@@ -911,7 +881,7 @@ func readBackupLocation(name, namespace, filePath string) (*storkapi.BackupLocat
 	return out, nil
 }
 
-func createS3Secret(secretName string, backupLocation *storkapi.BackupLocation, namespace string) error {
+func createS3Secret(secretName string, backupLocation *storkapi.BackupLocation, namespace string, labels map[string]string) error {
 	credentialData := make(map[string][]byte)
 	credentialData["endpoint"] = []byte(backupLocation.Location.S3Config.Endpoint)
 	credentialData["accessKey"] = []byte(backupLocation.Location.S3Config.AccessKeyID)
@@ -921,36 +891,36 @@ func createS3Secret(secretName string, backupLocation *storkapi.BackupLocation, 
 	credentialData["type"] = []byte(backupLocation.Location.Type)
 	credentialData["password"] = []byte(backupLocation.Location.RepositoryPassword)
 	credentialData["disablessl"] = []byte(strconv.FormatBool(backupLocation.Location.S3Config.DisableSSL))
-	err := createJobSecret(secretName, namespace, credentialData)
+	err := createJobSecret(secretName, namespace, credentialData, labels)
 
 	return err
 }
 
-func createGoogleSecret(secretName string, backupLocation *storkapi.BackupLocation, namespace string) error {
+func createGoogleSecret(secretName string, backupLocation *storkapi.BackupLocation, namespace string, labels map[string]string) error {
 	credentialData := make(map[string][]byte)
 	credentialData["type"] = []byte(backupLocation.Location.Type)
 	credentialData["password"] = []byte(backupLocation.Location.RepositoryPassword)
 	credentialData["accountkey"] = []byte(backupLocation.Location.GoogleConfig.AccountKey)
 	credentialData["projectid"] = []byte(backupLocation.Location.GoogleConfig.ProjectID)
 	credentialData["path"] = []byte(backupLocation.Location.Path)
-	err := createJobSecret(secretName, namespace, credentialData)
+	err := createJobSecret(secretName, namespace, credentialData, labels)
 
 	return err
 }
 
-func createAzureSecret(secretName string, backupLocation *storkapi.BackupLocation, namespace string) error {
+func createAzureSecret(secretName string, backupLocation *storkapi.BackupLocation, namespace string, labels map[string]string) error {
 	credentialData := make(map[string][]byte)
 	credentialData["type"] = []byte(backupLocation.Location.Type)
 	credentialData["password"] = []byte(backupLocation.Location.RepositoryPassword)
 	credentialData["path"] = []byte(backupLocation.Location.Path)
 	credentialData["storageaccountname"] = []byte(backupLocation.Location.AzureConfig.StorageAccountName)
 	credentialData["storageaccountkey"] = []byte(backupLocation.Location.AzureConfig.StorageAccountKey)
-	err := createJobSecret(secretName, namespace, credentialData)
+	err := createJobSecret(secretName, namespace, credentialData, labels)
 
 	return err
 }
 
-func createCertificateSecret(secretName, namespace string) error {
+func createCertificateSecret(secretName, namespace string, labels map[string]string) error {
 	drivers.CertFilePath = os.Getenv(drivers.CertDirPath)
 	if drivers.CertFilePath != "" {
 		certificateData, err := ioutil.ReadFile(filepath.Join(drivers.CertFilePath, drivers.CertFileName))
@@ -962,7 +932,7 @@ func createCertificateSecret(secretName, namespace string) error {
 
 		certData := make(map[string][]byte)
 		certData[drivers.CertFileName] = certificateData
-		err = createJobSecret(secretName, namespace, certData)
+		err = createJobSecret(secretName, namespace, certData, labels)
 
 		return err
 	}
@@ -974,11 +944,13 @@ func createJobSecret(
 	secretName string,
 	namespace string,
 	credentialData map[string][]byte,
+	labels map[string]string,
 ) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: namespace,
+			Labels:    labels,
 			Annotations: map[string]string{
 				utils.SkipResourceAnnotation: "true",
 			},

--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -44,7 +44,7 @@ func (d Driver) StartJob(opts ...drivers.JobOption) (id string, err error) {
 	}
 	// DataExportName will be unique name when also generated from stork
 	// if there are multiple backups being triggered
-	jobName := toJobName(o.SourcePVCName)
+	jobName := o.DataExportName
 	logrus.Debugf("backup jobname: %s", jobName)
 	job, err := buildJob(jobName, o)
 	if err != nil {
@@ -261,10 +261,6 @@ func jobFor(
 	}
 
 	return job, nil
-}
-
-func toJobName(sourcePVCName string) string {
-	return fmt.Sprintf("%s-%s", utils.BackupJobPrefix, sourcePVCName)
 }
 
 func toRepoName(pvcName, pvcNamespace string) string {

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -45,13 +45,12 @@ func (d Driver) StartJob(opts ...drivers.JobOption) (id string, err error) {
 		return "", err
 	}
 
-	jobName := toJobName(o.DestinationPVCName)
+	jobName := o.DataExportName
 	job, err := jobFor(
 		o,
 		vb,
 		jobName,
 		utils.FrameCredSecretName(utils.RestoreJobPrefix, o.DataExportName),
-		o.Labels,
 	)
 	if err != nil {
 		return "", err
@@ -126,9 +125,8 @@ func jobFor(
 	vb *v1alpha1.VolumeBackup,
 	jobName,
 	credSecretName string,
-	labels map[string]string,
 ) (*batchv1.Job, error) {
-	labels = addJobLabels(labels)
+	labels := addJobLabels(jobOption.Labels)
 
 	resources, err := utils.JobResourceRequirements()
 	if err != nil {
@@ -257,10 +255,6 @@ func jobFor(
 	}
 
 	return job, nil
-}
-
-func toJobName(destinationPVC string) string {
-	return fmt.Sprintf("%s-%s", utils.RestoreJobPrefix, destinationPVC)
 }
 
 func addJobLabels(labels map[string]string) map[string]string {

--- a/pkg/drivers/utils/utils.go
+++ b/pkg/drivers/utils/utils.go
@@ -5,12 +5,14 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aquilax/truncate"
 	"github.com/portworx/kdmp/pkg/drivers"
 	"github.com/portworx/kdmp/pkg/version"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // NamespacedName returns a name in form "<namespace>/<name>".
@@ -206,4 +208,17 @@ func toResourceRequirements(requestCPU, requestMem, limitCPU, limitMem string) (
 			corev1.ResourceMemory: limitMemQ,
 		},
 	}, nil
+}
+
+// GetValidLabel - will validate the label to make sure the length is less than 63 and contains valid label format.
+// If the length is greater then 63, it will truncate to 63 character.
+func GetValidLabel(labelVal string) string {
+	if len(labelVal) > validation.LabelValueMaxLength {
+		labelVal = truncate.Truncate(labelVal, validation.LabelValueMaxLength, "", truncate.PositionEnd)
+		// make sure the truncated value does not end with the hyphen.
+		labelVal = strings.Trim(labelVal, "-")
+		// make sure the truncated value does not end with the dot.
+		labelVal = strings.Trim(labelVal, ".")
+	}
+	return labelVal
 }

--- a/pkg/executor/kopia/restore.go
+++ b/pkg/executor/kopia/restore.go
@@ -69,7 +69,7 @@ func runRestore(snapshotID, targetPath string) error {
 		status := &executor.Status{
 			LastKnownError: err,
 		}
-		if err = executor.WriteVolumeBackupStatus(status, volumeBackupName, bkpNamespace); err != nil {
+		if err = executor.WriteVolumeBackupStatus(status, volumeBackupName, restoreNamespace); err != nil {
 			errMsg := fmt.Sprintf("failed to write a VolumeBackup status: %v", err)
 			logrus.Errorf("%v", errMsg)
 			return fmt.Errorf(errMsg)


### PR DESCRIPTION
**What this PR does / why we need it**:
```
    pb-1941: Changed the name format for all the kdmp generic backup
    resource.

        - name format <backup>-<shortUID of backup CR>-<shortID of
          PVC>-<NS>
        - Added required values like backup object name, uid, pvc name
          and id as label in the dataexport, volumebackup, jobs, secret
          resource, so that it can be used for filtering, while debugging.
```
**Which issue(s) this PR fixes** (optional)
Closes # PB-1941

**Special notes for your reviewer**:
Testing:
1) implemented below naming format for the generic backupResource like DataExport, VolumeBackup, Jobs, secret, roles, roleBindings, ServiceAccount and job pods. 
```
For Backup related resource:
backup-<shortUID of backup CR UID>-<short ID of PVC>-<Namespace>

For restore related resource:
restore-<shortUID of backup CR UID>-<short ID of PVC>-<Namespace>

For delete related resource:
delete-<shortUID of backup CR UID>-<short ID of PVC>-<Namespace>
```
**Note: namespace will truncate to match the 63 label length limit.**
**Also did not include the resourceType in the names. I was creating the DataExport CR name and passed to KDMP controller and using it for other resources like secret, volumeBackup, role, rolebinding, serviceAccount and job. So i do want to recreate the names to include different resourcType in the name.**

**Backup Related resource snapshot:**
![Screenshot 2021-10-02 at 7 03 53 PM](https://user-images.githubusercontent.com/52188641/135723213-2539986b-6992-4930-a39a-dc4fd86f099f.png)

**Restore related resource snapshot:**
![Screenshot 2021-10-02 at 7 08 15 PM](https://user-images.githubusercontent.com/52188641/135723245-03b59803-d1b7-4c56-8f1d-6e5eb2f7a16a.png)

**Made sure that all the resource are cleanup:**
![Screenshot 2021-10-02 at 7 05 51 PM](https://user-images.githubusercontent.com/52188641/135723273-fe43c93c-c5dc-4138-8acf-f6e5201c7ff6.png)

**Labels added as part of the resources:(DataExport):**
![Screenshot 2021-10-02 at 8 46 57 PM](https://user-images.githubusercontent.com/52188641/135723298-3e180b57-49a2-4fcd-8d0c-a92ae7f9d24d.png)

**Delete related resources snapshot:**
![Screenshot 2021-10-02 at 8 40 44 PM](https://user-images.githubusercontent.com/52188641/135723331-45a40761-4d54-4075-aab0-fe62aa7fc46c.png)

