### PR TITLE
PB-1942: Check if the job pods are running if VolumeBackup CR is not found

### DIFF
--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -117,6 +117,11 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 
 	vb, err := kdmpops.Instance().GetVolumeBackup(context.Background(), name, namespace)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			if utils.IsJobPending(job) {
+				return utils.ToJobStatus(0, "job is in pending state"), nil
+			}
+		}
 		errMsg := fmt.Sprintf("failed to fetch volumebackup %s/%s status: %v", namespace, name, err)
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)


### PR DESCRIPTION
**What this PR does / why we need it**:
-  Do not fail the generic backup if VolumeBackup CR is not found and the job
pod is in waiting state.


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

