### PR TITLE
PB-1947:  Fixing passing correct secret name to job pod

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -177,7 +177,6 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 			}
 			// This will create a unique secret per PVC being restored
 			// For restore create the secret in the ns where PVC is referenced
-
 			err = CreateCredentialsSecret(
 				dataExport.Name,
 				vb.Spec.BackupLocation.Name,
@@ -263,6 +262,7 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 			logrus.Errorf("%v", errMsg)
 			return false, c.updateStatus(dataExport, kdmpapi.DataExportStatusFailed, errMsg)
 		}
+
 		if err := c.cleanUp(driver, dataExport); err != nil {
 			msg := fmt.Sprintf("failed to remove resources: %s", err)
 			return false, c.updateStatus(dataExport, kdmpapi.DataExportStatusFailed, msg)

--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -137,8 +137,7 @@ func (d Driver) validate(o drivers.JobOpts) error {
 
 func jobFor(
 	jobOption drivers.JobOpts,
-	jobName,
-	credSecretName string,
+	jobName string,
 	resources corev1.ResourceRequirements,
 ) (*batchv1.Job, error) {
 	backupName := jobName
@@ -153,7 +152,7 @@ func jobFor(
 		"--repository",
 		toRepoName(jobOption.SourcePVCName, jobOption.Namespace),
 		"--credentials",
-		credSecretName,
+		jobOption.DataExportName,
 		"--backup-location",
 		jobOption.BackupLocationName,
 		"--backup-location-namespace",
@@ -217,7 +216,7 @@ func jobFor(
 							Name: "cred-secret",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: credSecretName,
+									SecretName: jobOption.DataExportName,
 								},
 							},
 						},
@@ -300,7 +299,6 @@ func buildJob(jobName string, jobOptions drivers.JobOpts) (*batchv1.Job, error) 
 		return jobForLiveBackup(
 			jobOptions,
 			jobName,
-			utils.FrameCredSecretName(utils.BackupJobPrefix, jobOptions.DataExportName),
 			pods[0],
 			resources,
 		)
@@ -309,7 +307,6 @@ func buildJob(jobName string, jobOptions drivers.JobOpts) (*batchv1.Job, error) 
 	return jobFor(
 		jobOptions,
 		jobName,
-		utils.FrameCredSecretName(utils.BackupJobPrefix, jobOptions.DataExportName),
 		resources,
 	)
 }

--- a/pkg/drivers/kopiabackup/kopiabackuplive.go
+++ b/pkg/drivers/kopiabackup/kopiabackuplive.go
@@ -19,8 +19,7 @@ var (
 
 func jobForLiveBackup(
 	jobOption drivers.JobOpts,
-	jobName,
-	credSecretName string,
+	jobName string,
 	mountPod corev1.Pod,
 	resources corev1.ResourceRequirements,
 ) (*batchv1.Job, error) {
@@ -43,7 +42,7 @@ func jobForLiveBackup(
 		"--volume-backup-name",
 		backupName,
 		"--credentials",
-		credSecretName,
+		jobOption.DataExportName,
 		"--backup-location",
 		jobOption.BackupLocationName,
 		"--backup-location-namespace",
@@ -110,7 +109,7 @@ func jobForLiveBackup(
 							Name: "cred-secret",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: credSecretName,
+									SecretName: jobOption.DataExportName,
 								},
 							},
 						},

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -50,7 +50,6 @@ func (d Driver) StartJob(opts ...drivers.JobOption) (id string, err error) {
 		o,
 		vb,
 		jobName,
-		utils.FrameCredSecretName(utils.RestoreJobPrefix, o.DataExportName),
 	)
 	if err != nil {
 		return "", err
@@ -123,8 +122,7 @@ func (d Driver) validate(o drivers.JobOpts) error {
 func jobFor(
 	jobOption drivers.JobOpts,
 	vb *v1alpha1.VolumeBackup,
-	jobName,
-	credSecretName string,
+	jobName string,
 ) (*batchv1.Job, error) {
 	labels := addJobLabels(jobOption.Labels)
 
@@ -151,7 +149,7 @@ func jobFor(
 		"--restore-namespace",
 		jobOption.Namespace,
 		"--credentials",
-		credSecretName,
+		jobOption.DataExportName,
 		"--target-path",
 		"/data",
 		"--snapshot-id",
@@ -211,7 +209,7 @@ func jobFor(
 							Name: "cred-secret",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: credSecretName,
+									SecretName: jobOption.DataExportName,
 								},
 							},
 						},

--- a/pkg/drivers/utils/common.go
+++ b/pkg/drivers/utils/common.go
@@ -84,8 +84,3 @@ func serviceAccountFor(name, namespace string) *corev1.ServiceAccount {
 		},
 	}
 }
-
-// FrameCredSecretName frames credential secret name
-func FrameCredSecretName(prefix, deName string) string {
-	return prefix + "-" + deName
-}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing passing correct secret name as per new naming convention to job pods.

**Which issue(s) this PR fixes** (optional)
PB-1947

**Special notes for your reviewer**:

Before fixing the failure messages
Pod description when the failure occured

```
Events:
  Type     Reason       Age               From     Message
  ----     ------       ----              ----     -------
  Warning  FailedMount  3s (x5 over 10s)  kubelet  MountVolume.SetUp failed for volume "cred-secret" : secret "b-backup-42662d5-84337b7-mysql" not found
[root@prashanth-maple-palm-1 specs]# k describe pod backup-42662d5-84337b7-mysql-9rpj9 -nmysql
Error from server (NotFound): pods "backup-42662d5-84337b7-mysql-9rpj9" not found
```