### PR TITLE
pb-1948: fixed the issue in cron job schedule string.

### DIFF
--- a/pkg/drivers/kopiamaintenance/kopiamaintenance.go
+++ b/pkg/drivers/kopiamaintenance/kopiamaintenance.go
@@ -17,8 +17,8 @@ import (
 
 const (
 	kopiaMaintenanceJobPrefix         = "repo-maintenance"
-	defaultFullSchedule               = "*/* 24 * * *"
-	defaultQuickSchedule              = "*/* 2 * * *"
+	defaultFullSchedule               = "0 */24 * * *"
+	defaultQuickSchedule              = "0 */2 * * *"
 	fullMaintenanceType               = "full"
 	quickMaintenaceTye                = "quick"
 	defaultFailedJobsHistoryLimit     = 1


### PR DESCRIPTION
**What this PR does / why we need it**:
pb-1948: fixed the issue in cron job schedule string.
**Which issue(s) this PR fixes** (optional)
Closes # pb-1948

**Special notes for your reviewer**:
With the current string, it was failing with below error.
```
time="2021-10-06T07:24:50Z" level=error msg="StartJob: creation of maintenance job [full-maintenance-repo-dbfa25d] for backuplocation [location1] failed: CronJob.batch \"full-maintenance-repo-dbfa25d\" is invalid: spec.schedule: Invalid value: \"*/* 24 * * *\": Failed to parse int from *: strconv.Atoi: parsing \"*\": invalid syntax"
time="2021-10-06T07:24:50Z" level=warning msg="checkBackupLocationMaintenaceCronjob: failed in creating maintenance secret for backuplocation[location1:dbfa25dd-0767-467a-989c-cc99aef6d8ce]: failed in starting kdmp cron job for full maintenance for backuplocation [location1]: creation of maintenance job [full-maintenance-repo-dbfa25d] for backuplocation [location1] failed: CronJob.batch \"full-maintenance-repo-dbfa25d\" is invalid: spec.schedule: Invalid value: \"*/* 24 * * *\": Failed to parse int from *: strconv.Atoi: parsing \"*\": invalid syntax"
```
After checking the below link, change it to correct format for 24 hr and 2 hr.
https://www.guru99.com/crontab-in-linux-with-examples.html
![Screenshot 2021-10-06 at 3 03 34 PM](https://user-images.githubusercontent.com/52188641/136177827-6634ca92-305b-44c8-a06f-5c990c1f7898.png)

Note: 
Verified with px-backup, by adding the backuplocation.
```
Every 2.0s: kubectl get cronjob -n px-backup                                                                                                                                               Wed Oct  6 09:35:31 2021

NAME                             SCHEDULE 	SUSPEND   ACTIVE   LAST SCHEDULE   AGE
full-maintenance-repo-15a0940    0 */24 * * *   False     0        <none>          5s
quick-maintenance-repo-15a0940   0 */2 * * *    False     0        <none>          5s
```

