### PR TITLE
PB-1959: Fixing google repository create issue

### DIFF
--- a/pkg/kopia/command.go
+++ b/pkg/kopia/command.go
@@ -87,7 +87,26 @@ func (c *Command) CreateCmd() *exec.Cmd {
 			"--prefix",
 			c.RepositoryName,
 		}
-	case "s3", "google":
+	case "s3":
+		argsSlice = []string{
+			"repository",
+			c.Name, // create command
+			c.Provider,
+			"--bucket",
+			c.Path,
+			"--password",
+			c.Password,
+			"--prefix",
+			c.RepositoryName,
+		}
+
+		if c.DisableSsl {
+			ssl := []string{
+				"--disable-tls",
+			}
+			argsSlice = append(argsSlice, ssl...)
+		}
+	case "gcs":
 		argsSlice = []string{
 			"repository",
 			c.Name, // create command
@@ -100,13 +119,7 @@ func (c *Command) CreateCmd() *exec.Cmd {
 			c.RepositoryName,
 		}
 	}
-	var ssl []string
-	if c.DisableSsl {
-		ssl = []string{
-			"--disable-tls",
-		}
-	}
-	argsSlice = append(argsSlice, ssl...)
+
 	argsSlice = append(argsSlice, c.Flags...)
 	// Get the cmd args
 	argsSlice = append(argsSlice, c.Args...)
@@ -152,7 +165,25 @@ func (c *Command) ConnectCmd() *exec.Cmd {
 			"--prefix",
 			c.RepositoryName,
 		}
-	case "s3", "google":
+	case "s3":
+		argsSlice = []string{
+			"repository",
+			c.Name, // connect command
+			c.Provider,
+			"--bucket",
+			c.Path,
+			"--password",
+			c.Password,
+			"--prefix",
+			c.RepositoryName,
+		}
+		if c.DisableSsl {
+			ssl := []string{
+				"--disable-tls",
+			}
+			argsSlice = append(argsSlice, ssl...)
+		}
+	case "gcs":
 		argsSlice = []string{
 			"repository",
 			c.Name, // connect command
@@ -165,14 +196,8 @@ func (c *Command) ConnectCmd() *exec.Cmd {
 			c.RepositoryName,
 		}
 	}
-	var ssl []string
-	if c.DisableSsl {
-		ssl = []string{
-			"--disable-tls",
-		}
-	}
+
 	argsSlice = append(argsSlice, c.Flags...)
-	argsSlice = append(argsSlice, ssl...)
 	// Get the cmd args
 	argsSlice = append(argsSlice, c.Args...)
 	cmd := exec.Command(baseCmd, argsSlice...)


### PR DESCRIPTION
**What this PR does / why we need it**:
- Not passing disable-tls for google
- Changed command to gcs from google


**Which issue(s) this PR fixes** (optional)
PB-1959

**Special notes for your reviewer**:

Manual test
Pod logs
```
+ /kopiaexecutor backup --volume-backup-name backup-0fcbfe8-5405c0d-mysql --credentials backup-0fcbfe8-5405c0d-mysql --backup-location gke-bl-883d9e7 --backup-location-namespace mysql --backup-namespace mysql --repository mysql-mysql-proxy-data --source-path-glob /data/kubernetes.io~portworx-volume/pvc-5405c0d0-3df5-40d1-a29e-64095db4e437
time="2021-10-13T18:46:46Z" level=info msg="type: google"
time="2021-10-13T18:46:46Z" level=info msg="kopia.repository doesn't exists"
time="2021-10-13T18:46:46Z" level=info msg="Repository creation started"
time="2021-10-13T18:46:46Z" level=info msg="line 205 repoCreateCmd: &{Name:create Path:prashanth-bucket RepositoryName:generic-backup/mysql-mysql-proxy-data/ Dir: Args:[] Flags:[] Env:[] Password:k0p1@#GB Provider:gcs SnapshotID: MaintenanceOwner: DisableSsl:false}"
time="2021-10-13T18:46:46Z" level=info msg="line 133 cmd: /usr/bin/kopia repository create gcs --bucket prashanth-bucket --password k0p1@#GB --prefix generic-backup/mysql-mysql-proxy-data/ --credentials-file /etc/cred-secret/accountkey"
2021/10/13 18:46:46 repo create status not available Next retry in: 5s
time="2021-10-13T18:46:51Z" level=info msg="Repository creation successful"
time="2021-10-13T18:46:51Z" level=info msg="Setting global policy"
time="2021-10-13T18:46:51Z" level=info msg="Global policy set successfully"
time="2021-10-13T18:46:51Z" level=info msg="Repository connect started"
time="2021-10-13T18:46:51Z" level=info msg="line 211 connectcmd: /usr/bin/kopia repository connect gcs --bucket prashanth-bucket --password k0p1@#GB --prefix generic-backup/mysql-mysql-proxy-data/ --credentials-file /etc/cred-secret/accountkey"
2021/10/13 18:46:51 repository connect status not available Next retry in: 5s
time="2021-10-13T18:46:56Z" level=info msg="kopia repo connect successful .."
time="2021-10-13T18:46:56Z" level=info msg="Backup started"
time="2021-10-13T18:47:06Z" level=info msg="Backup successful"
```
![Screenshot 2021-10-14 at 12 14 33 AM (2)](https://user-images.githubusercontent.com/51692473/137195424-12405b41-af8b-4b77-b253-41fc2e1e8028.png)

