### PR TITLE
pb-1961: Delete job ratelimit is broken as delete drivertype was not updated with correct type.

### DIFF
--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -281,7 +281,7 @@ func addJobLabels(labels map[string]string, jobOpts drivers.JobOpts) map[string]
 		labels = make(map[string]string)
 	}
 
-	labels[drivers.DriverNameLabel] = drivers.KopiaBackup
+	labels[drivers.DriverNameLabel] = drivers.KopiaDelete
 	labels[utils.BackupObjectNameKey] = jobOpts.BackupObjectName
 	labels[utils.BackupObjectUIDKey] = jobOpts.BackupObjectUID
 	return labels


### PR DESCRIPTION
**What this PR does / why we need it**:
pb-1961: Delete job ratelimit is broken as delete drivertype was not updated with correct type.

**Which issue(s) this PR fixes** (optional)
Closes #pb-1961

**Special notes for your reviewer**:
**Testing:**
Verified that delete job rate limit limits the delete jobs to five count.
<img width="1792" alt="Screenshot 2021-10-14 at 2 52 15 AM" src="https://user-images.githubusercontent.com/52188641/137214379-5213b0a6-488c-4a1e-94b1-3a25d5de076c.png">


