### PR TITLE
pb-1967: Added SkipResourceAnnotation for generic backup resources like job, roles, rolebindings and service account.

### DIFF
--- a/pkg/drivers/kopiabackup/kopiabackuplive.go
+++ b/pkg/drivers/kopiabackup/kopiabackuplive.go
@@ -59,7 +59,10 @@ func jobForLiveBackup(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: jobOption.Namespace,
-			Labels:    labels,
+			Annotations: map[string]string{
+				utils.SkipResourceAnnotation: "true",
+			},
+			Labels: labels,
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{

--- a/pkg/drivers/utils/common.go
+++ b/pkg/drivers/utils/common.go
@@ -30,6 +30,9 @@ const (
 func SetupServiceAccount(name, namespace string, role *rbacv1.Role) error {
 	if role != nil {
 		role.Name, role.Namespace = name, namespace
+		role.Annotations = map[string]string{
+			SkipResourceAnnotation: "true",
+		}
 		if _, err := rbacops.Instance().CreateRole(role); err != nil && !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("create %s/%s role: %s", namespace, name, err)
 		}
@@ -62,6 +65,9 @@ func roleBindingFor(name, namespace string) *rbacv1.RoleBinding {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Annotations: map[string]string{
+				SkipResourceAnnotation: "true",
+			},
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -83,6 +89,9 @@ func serviceAccountFor(name, namespace string) *corev1.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Annotations: map[string]string{
+				SkipResourceAnnotation: "true",
+			},
 		},
 	}
 }

--- a/pkg/executor/common.go
+++ b/pkg/executor/common.go
@@ -13,6 +13,7 @@ import (
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	kdmpapi "github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
 	"github.com/portworx/kdmp/pkg/drivers"
+	"github.com/portworx/kdmp/pkg/drivers/utils"
 	kdmpops "github.com/portworx/kdmp/pkg/util/ops"
 	kdmpschedops "github.com/portworx/sched-ops/k8s/kdmp"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
@@ -437,6 +438,9 @@ func CreateVolumeBackup(name, namespace, repository, blName, blNamespace string)
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Annotations: map[string]string{
+				utils.SkipResourceAnnotation: "true",
+			},
 		},
 		Spec: kdmpapi.VolumeBackupSpec{
 			Repository: repository,


### PR DESCRIPTION
**What this PR does / why we need it**:
pb-1967: Added SkipResourceAnnotation for generic backup resources like job, roles, rolebindings and service account.
**Which issue(s) this PR fixes** (optional)
Closes #pb-1967

**Special notes for your reviewer**:
Testing:
Verified that SkipResourceAnnotation token is added to the jobs, roles, rolesbinding, volumebackup and service account.
**One known issue is pending. The secret-serviceaccount-token created automatically for the service account is getting updated with the SkipResourceAnnotation annotaiton. Will fix it in separate PR.**
