### PR TITLE
 Adding retires in reonciler in final stage [Do not Review]

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -23,6 +23,7 @@ import (
 	kdmpopts "github.com/portworx/kdmp/pkg/util/ops"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/stork"
+	"github.com/portworx/sched-ops/task"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -51,6 +52,9 @@ const (
 	volumeinitialDelay = 2 * time.Second
 	volumeFactor       = 1.5
 	volumeSteps        = 20
+	//defaultTimeout           = 1 * time.Minute
+	defaultTimeout        = 20 * time.Second
+	progressCheckInterval = 5 * time.Second
 )
 
 var volumeAPICallBackoff = wait.Backoff{
@@ -239,9 +243,17 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 		dataExport.Status.ProgressPercentage = int(progress.ProgressPercents)
 		return false, c.updateStatus(dataExport, kdmpapi.DataExportStatusInProgress, "")
 	case kdmpapi.DataExportStageFinal:
-		if dataExport.Status.Status == kdmpapi.DataExportStatusSuccessful {
+		// If we have a failure case in this stage it means in the previous stage
+		// all retries were done in cleaning up resources and failed.
+		// In such a case we don't want to proceed further as stork will
+		// eventually clean up DE CR.
+		// Without this, we would again see the resource cleanup error and move
+		// the status to DataExportStatusInProgress which is not desireable
+		if dataExport.Status.Status == kdmpapi.DataExportStatusSuccessful ||
+			dataExport.Status.Status == kdmpapi.DataExportStatusFailed {
 			return false, nil
 		}
+
 		var vbName string
 		var vbNamespace string
 		if driverName == drivers.KopiaBackup {
@@ -257,28 +269,80 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 			vbName = dataExport.Spec.Source.Name
 			vbNamespace = dataExport.Spec.Source.Namespace
 		}
-
-		volumeBackupCR, err := kdmpopts.Instance().GetVolumeBackup(context.Background(),
-			vbName, vbNamespace)
-		if err != nil {
-			errMsg := fmt.Sprintf("failed to read VolumeBackup CR %v: %v", vbName, err)
+		var volumeBackupCR *kdmpapi.VolumeBackup
+		var vbErr error
+		vbTask := func() (interface{}, bool, error) {
+			volumeBackupCR, vbErr = kdmpopts.Instance().GetVolumeBackup(context.Background(),
+				vbName, vbNamespace)
+			if errors.IsNotFound(vbErr) {
+				errMsg := fmt.Sprintf("volumebackup CR %v/%v not found", vbNamespace, vbName)
+				logrus.Errorf("%v", errMsg)
+				return "", false, fmt.Errorf(errMsg)
+			}
+			// Dummy error
+			//vbErr := fmt.Errorf("error simulation")
+			if vbErr != nil {
+				errMsg := fmt.Sprintf("failed to read VolumeBackup CR %v: %v", vbName, err)
+				logrus.Errorf("%v", errMsg)
+				err := c.updateStatus(dataExport, kdmpapi.DataExportStatusInProgress, "")
+				if err != nil {
+					return "", false, fmt.Errorf("%v", err)
+				}
+				return "", true, fmt.Errorf("%v", errMsg)
+			}
+			return "", false, nil
+		}
+		if _, err := task.DoRetryWithTimeout(vbTask, defaultTimeout, progressCheckInterval); err != nil {
+			errMsg := fmt.Sprintf("max retries done, failed to read VolumeBackup CR %v: %v", vbName, err)
+			logrus.Errorf("%v", errMsg)
+			// Exhausted all retries, fail the CR
 			return false, c.updateStatus(dataExport, kdmpapi.DataExportStatusFailed, errMsg)
 		}
+
 		dataExport.Status.SnapshotID = volumeBackupCR.Status.SnapshotID
 		dataExport.Status.Size = volumeBackupCR.Status.TotalBytes
-		// Delete the tls certificate secret created
-		err = core.Instance().DeleteSecret(drivers.CertSecretName, dataExport.Spec.Source.Namespace)
-		if err != nil && errors.IsAlreadyExists(err) {
-			errMsg := fmt.Sprintf("failed to delete [%s:%s] secret", dataExport.Spec.Source.Namespace, drivers.CertSecretName)
+		tlsTask := func() (interface{}, bool, error) {
+			// Delete the tls certificate secret created
+			err = core.Instance().DeleteSecret(drivers.CertSecretName, dataExport.Spec.Source.Namespace)
+			if err != nil && errors.IsAlreadyExists(err) {
+				errMsg := fmt.Sprintf("failed to delete [%s/%s] secret", dataExport.Spec.Source.Namespace, drivers.CertSecretName)
+				logrus.Errorf("%v", errMsg)
+				//return false, c.updateStatus(dataExport, kdmpapi.DataExportStatusFailed, errMsg)
+				err := c.updateStatus(dataExport, kdmpapi.DataExportStatusInProgress, "")
+				if err != nil {
+					return "", false, fmt.Errorf("%v", err)
+				}
+				return "", true, fmt.Errorf("%v", errMsg)
+			}
+			return "", false, nil
+		}
+		if _, err := task.DoRetryWithTimeout(tlsTask, defaultTimeout, progressCheckInterval); err != nil {
+			errMsg := fmt.Sprintf("max retries done, failed to delete [%s/%s] secret", dataExport.Spec.Source.Namespace, drivers.CertSecretName)
 			logrus.Errorf("%v", errMsg)
+			// Exhausted all retries, fail the CR
 			return false, c.updateStatus(dataExport, kdmpapi.DataExportStatusFailed, errMsg)
 		}
 
-		if err := c.cleanUp(driver, dataExport); err != nil {
-			msg := fmt.Sprintf("failed to remove resources: %s", err)
-			return false, c.updateStatus(dataExport, kdmpapi.DataExportStatusFailed, msg)
-		}
+		cleanupTask := func() (interface{}, bool, error) {
+			err := c.cleanUp(driver, dataExport)
+			if err != nil {
+				errMsg := fmt.Sprintf("failed to remove resources: %s", err)
+				logrus.Errorf("%v", errMsg)
+				err := c.updateStatus(dataExport, kdmpapi.DataExportStatusInProgress, "")
+				if err != nil {
+					return "", false, fmt.Errorf("%v", err)
+				}
+				return "", true, fmt.Errorf("%v", errMsg)
+			}
 
+			return "", false, nil
+		}
+		if _, err := task.DoRetryWithTimeout(cleanupTask, defaultTimeout, progressCheckInterval); err != nil {
+			errMsg := fmt.Sprintf("max retries done, failed to delete [%s:%s] secret", dataExport.Spec.Source.Namespace, drivers.CertSecretName)
+			logrus.Errorf("%v", errMsg)
+			// Exhausted all retries, fail the CR
+			return false, c.updateStatus(dataExport, kdmpapi.DataExportStatusFailed, errMsg)
+		}
 		return true, c.client.Update(ctx, setStatus(dataExport, kdmpapi.DataExportStatusSuccessful, ""))
 	}
 
@@ -534,7 +598,23 @@ func (c *Controller) updateStatus(de *kdmpapi.DataExport, status kdmpapi.DataExp
 	if isStatusEqual(de, status, errMsg) {
 		return nil
 	}
-	return c.client.Update(context.TODO(), setStatus(de, status, errMsg))
+	t := func() (interface{}, bool, error) {
+		err := c.client.Update(context.TODO(), setStatus(de, status, errMsg))
+		if err != nil {
+			errMsg := fmt.Sprintf("failed updating DE CR %s to status %v: %v", de.Name, status, err)
+			logrus.Errorf("%v", errMsg)
+			return "", true, fmt.Errorf("%v", errMsg)
+		}
+
+		return "", false, nil
+	}
+	if _, err := task.DoRetryWithTimeout(t, defaultTimeout, progressCheckInterval); err != nil {
+		errMsg := fmt.Sprintf("max retries done, failed updating DE CR %s to status %v: %v", de.Name, status, err)
+		logrus.Errorf("%v", errMsg)
+		// Exhausted all retries, fail the CR
+		return err
+	}
+	return nil
 }
 
 func (c *Controller) restoreSnapshot(ctx context.Context, snapshotDriver snapshotter.Driver, de *kdmpapi.DataExport) (*corev1.PersistentVolumeClaim, error) {

--- a/pkg/kopia/command.go
+++ b/pkg/kopia/command.go
@@ -87,7 +87,26 @@ func (c *Command) CreateCmd() *exec.Cmd {
 			"--prefix",
 			c.RepositoryName,
 		}
-	case "s3", "google":
+	case "s3":
+		argsSlice = []string{
+			"repository",
+			c.Name, // create command
+			c.Provider,
+			"--bucket",
+			c.Path,
+			"--password",
+			c.Password,
+			"--prefix",
+			c.RepositoryName,
+		}
+
+		if c.DisableSsl {
+			ssl := []string{
+				"--disable-tls",
+			}
+			argsSlice = append(argsSlice, ssl...)
+		}
+	case "gcs":
 		argsSlice = []string{
 			"repository",
 			c.Name, // create command
@@ -100,13 +119,7 @@ func (c *Command) CreateCmd() *exec.Cmd {
 			c.RepositoryName,
 		}
 	}
-	var ssl []string
-	if c.DisableSsl {
-		ssl = []string{
-			"--disable-tls",
-		}
-	}
-	argsSlice = append(argsSlice, ssl...)
+
 	argsSlice = append(argsSlice, c.Flags...)
 	// Get the cmd args
 	argsSlice = append(argsSlice, c.Args...)
@@ -152,7 +165,25 @@ func (c *Command) ConnectCmd() *exec.Cmd {
 			"--prefix",
 			c.RepositoryName,
 		}
-	case "s3", "google":
+	case "s3":
+		argsSlice = []string{
+			"repository",
+			c.Name, // connect command
+			c.Provider,
+			"--bucket",
+			c.Path,
+			"--password",
+			c.Password,
+			"--prefix",
+			c.RepositoryName,
+		}
+		if c.DisableSsl {
+			ssl := []string{
+				"--disable-tls",
+			}
+			argsSlice = append(argsSlice, ssl...)
+		}
+	case "gcs":
 		argsSlice = []string{
 			"repository",
 			c.Name, // connect command
@@ -165,14 +196,8 @@ func (c *Command) ConnectCmd() *exec.Cmd {
 			c.RepositoryName,
 		}
 	}
-	var ssl []string
-	if c.DisableSsl {
-		ssl = []string{
-			"--disable-tls",
-		}
-	}
+
 	argsSlice = append(argsSlice, c.Flags...)
-	argsSlice = append(argsSlice, ssl...)
 	// Get the cmd args
 	argsSlice = append(argsSlice, c.Args...)
 	cmd := exec.Command(baseCmd, argsSlice...)


### PR DESCRIPTION
**What this PR does / why we need it**:
    - Upon deleting resources in the final stage, do retries if there is a failure on
      deleting a resource
    - With this, any failure in the final stage is considered a final failure

**Which issue(s) this PR fixes** (optional)
PB-1952

**Special notes for your reviewer**:

**Manual test**
1. Simulated error in the code upon reading CR
2. Checked the logs, retires are happening
3. Once all retries are exhausted, stork deletes the DE CR

Some ref logs
```
time="2021-10-19T15:04:39Z" level=error msg="failed to read VolumeBackup CR backup-5134563-5405c0d-mysql: <nil>"
2021/10/19 15:04:39 failed to read VolumeBackup CR backup-5134563-5405c0d-mysql: <nil> Next retry in: 5s
```
