### PR TITLE
pb-1975: excluding the completed jobs from the job ratelimit count calculation.

### DIFF
--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -79,9 +79,9 @@ const (
 	DefaultResticExecutorRequestMemory = "700Mi"
 	DefaultResticExecutorLimitCPU      = "2"
 	DefaultResticExecutorLimitMemory   = "1Gi"
-	DefaultKopiaExecutorRequestCPU     = "1"
+	DefaultKopiaExecutorRequestCPU     = "0.1"
 	DefaultKopiaExecutorRequestMemory  = "700Mi"
-	DefaultKopiaExecutorLimitCPU       = "2"
+	DefaultKopiaExecutorLimitCPU       = "0.2"
 	DefaultKopiaExecutorLimitMemory    = "1Gi"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
pb-1975: excluding the completed jobs from the job ratelimit count
    calculation.

        - pb-1977: Reduce the cpu resource limit and request to 0.2 and
          0.1 for kopia jobs in kdmp
**Which issue(s) this PR fixes** (optional)
Closes #pb-1975, pb-1977

**Special notes for your reviewer**:
Testing:
With the above change, verified that job scheduling happened once the jobs are completed. It was not waiting for the waiting for the completed jobs to be deleted.
![Screenshot 2021-10-22 at 8 56 33 AM](https://user-images.githubusercontent.com/52188641/138388604-f5f13a4a-b743-4e17-ae2d-8861b9d5bdb5.png)


