### PR TITLE
Travis changes for 1.0.0 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ script:
   - |
     if [ -n "${TRAVIS_TAG}" ]; then
       export RELEASE_VER=${TRAVIS_TAG}
-    elif [ "${TRAVIS_BRANCH}" == "master" ]; then
-      export DOCKER_IMAGE_TAG=master
+    elif [ "${TRAVIS_BRANCH}" == "1.0.0" ]; then
+      export DOCKER_IMAGE_TAG="1.0.0"
     else
       export RELEASE_VER=`git rev-parse --short HEAD`
     fi
@@ -20,6 +20,9 @@ script:
       docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}";
       make deploy;
     fi
+branches:
+  only:
+  - 1.0.0
 notifications:
   email:
     on_success: always

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ KOPIAEXECUTOR_DOCKER_IMAGE=$(DOCKER_IMAGE_REPO)/$(KOPIAEXECUTOR_DOCKER_IMAGE_NAM
 export GO111MODULE=on
 export GOFLAGS = -mod=vendor
 
+MAJOR_VERSION := 1
+MINOR_VERSION := 0
+PATCH_VERSION := 0
+
 ifndef PKGS
 	PKGS := $(shell GOFLAGS=-mod=vendor go list ./... 2>&1 | grep -v 'go: ' | grep -v 'github.com/portworx/kdmp/vendor' | grep -v versioned | grep -v 'pkg/apis/v1')
 endif
@@ -121,7 +125,10 @@ build-kdmp:
 	go build -o ${BIN}/kdmp -ldflags="-s -w \
 	-X github.com/portworx/kdmp/pkg/version.gitVersion=${RELEASE_VER} \
 	-X github.com/portworx/kdmp/pkg/version.gitCommit=${GIT_SHA} \
-	-X github.com/portworx/kdmp/pkg/version.buildDate=${BUILD_DATE}" \
+	-X github.com/portworx/kdmp/pkg/version.buildDate=${BUILD_DATE} \
+	-X github.com/portworx/kdmp/pkg/version.major=${MAJOR_VERSION} \
+	-X github.com/portworx/kdmp/pkg/version.minor=${MINOR_VERSION} \
+	-X github.com/portworx/kdmp/pkg/version.patch=${PATCH_VERSION}" \
 	$(BASE_DIR)/cmd/kdmp
 
 container-kdmp:
@@ -154,7 +161,10 @@ build-kopia-executor:
 	go build -o $(BIN)/kopiaexecutor -ldflags="-s -w \
 	-X github.com/portworx/kdmp/pkg/version.gitVersion=${RELEASE_VER} \
 	-X github.com/portworx/kdmp/pkg/version.gitCommit=${GIT_SHA} \
-	-X github.com/portworx/kdmp/pkg/version.buildDate=${BUILD_DATE}" \
+	-X github.com/portworx/kdmp/pkg/version.buildDate=${BUILD_DATE} \
+	-X github.com/portworx/kdmp/pkg/version.major=${MAJOR_VERSION} \
+	-X github.com/portworx/kdmp/pkg/version.minor=${MINOR_VERSION} \
+	-X github.com/portworx/kdmp/pkg/version.patch=${PATCH_VERSION}" \
 	$(BASE_DIR)/cmd/executor/kopia
 
 container-restic-executor:

--- a/pkg/executor/kopia/kopia.go
+++ b/pkg/executor/kopia/kopia.go
@@ -3,6 +3,8 @@ package kopia
 import (
 	"flag"
 
+	"github.com/portworx/kdmp/pkg/version"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubectl/pkg/cmd/util"
@@ -36,6 +38,8 @@ func NewCommand() *cobra.Command {
 		newDeleteCommand(),
 		newMaintenanceCommand(),
 	)
+	// Printing build version
+	logrus.Infof("Starting kopiaexecutor version: %v", version.ToString(version.Get()))
 	cmds.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	err := flag.CommandLine.Parse([]string{})
 	if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,8 +14,15 @@ var (
 	buildDate  = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )
 
+var major string
+var minor string
+var patch string
+
 // Info contains versioning information.
 type Info struct {
+	Major      string `json:"major"`
+	Minor      string `json:"minor"`
+	Patch      string `json:"patch"`
 	GitVersion string `json:"gitVersion"`
 	GitCommit  string `json:"gitCommit"`
 	BuildDate  string `json:"buildDate"`
@@ -32,6 +39,9 @@ func (info Info) String() string {
 // Get returns the overall codebase version.
 func Get() Info {
 	return Info{
+		Major:      major,
+		Minor:      minor,
+		Patch:      patch,
 		GitVersion: gitVersion,
 		GitCommit:  gitCommit,
 		BuildDate:  buildDate,
@@ -39,4 +49,9 @@ func Get() Info {
 		Compiler:   runtime.Compiler,
 		Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
+}
+
+// ToString returns a string representation of the version
+func ToString(i Info) string {
+	return fmt.Sprintf("%v.%v.%v-%v", i.Major, i.Minor, i.Patch, i.GitCommit)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Added Travis changes for 1.0.0
- Added build version in kopiaexecutor

**Which issue(s) this PR fixes** (optional)
PB-1979

**Special notes for your reviewer**:

```
[root@prashanth-winter-fighter-2 kdmp]# k logs -f backup-e17b9a5-5405c0d-mysql-x845b -nmysql
+ /kopiaexecutor backup --volume-backup-name backup-e17b9a5-5405c0d-mysql --credentials backup-e17b9a5-5405c0d-mysql --backup-location minio-bl-3b0789b --backup-location-namespace mysql --backup-namespace mysql --repository mysql-mysql-proxy-data --source-path-glob /data/kubernetes.io~portworx-volume/pvc-5405c0d0-3df5-40d1-a29e-64095db4e437
time="2021-10-22T12:56:21Z" level=info msg="Starting kopiaexecutor version: 1.0.0-02eb53a" --> version
time="2021-10-22T12:56:21Z" level=info msg="type: s3"
time="2021-10-22T12:56:22Z" level=info msg="kopia.repository exists"
time="2021-10-22T12:56:22Z" level=info msg="Repository connect started"
2021/10/22 12:56:22 repository connect status not available Next retry in: 5s
time="2021-10-22T12:56:27Z" level=info msg="kopia repo connect successful .."
time="2021-10-22T12:56:27Z" level=info msg="Backup started"
time="2021-10-22T12:56:37Z" level=info msg="Backup successful"
```