### PR TITLE
PB-1989: Setting kopia  to 0.9.4 version

### DIFF
--- a/Dockerfile.kopia
+++ b/Dockerfile.kopia
@@ -17,7 +17,7 @@ RUN apt-get update \
 
 RUN apt update
 
-RUN apt install kopia
+RUN apt install kopia=0.9.4
 WORKDIR /
 
 COPY ./bin/kopiaexecutor /


### PR DESCRIPTION
**What this PR does / why we need it**:
 Setting kopia  to 0.9.4 version

**Which issue(s) this PR fixes** (optional)
PB-1989

**Special notes for your reviewer**:

kopia version inside the job pod
```
[root@prashanth-winter-fighter-2 kdmp]# k exec -it backup-17e9826-5405c0d-mysql-rpth7 -nmysql bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
root@backup-17e9826-5405c0d-mysql-rpth7:/# kopia --version
0.9.4 build: 0d0f48a7ee741ef8263d608ef5bfef172ed4cf4f from: kopia/kopia

```
