### PR TITLE
PB-1984: Added support for compression during backup

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -67,6 +67,7 @@ const (
 	volumeSteps           = 20
 	defaultTimeout        = 1 * time.Minute
 	progressCheckInterval = 5 * time.Second
+	compressionKey        = "KDMP_COMPRESSION"
 )
 
 type updateDataExportDetail struct {
@@ -264,9 +265,18 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 			// For restore setting the source PVCName as the destination PVC name for the job
 			srcPVCName = dataExport.Spec.Destination.Name
 		}
-
+		// Read the config map to get compression type
+		var compressionType string
+		kdmpData, err := core.Instance().GetConfigMap(utils.KdmpConfigmapName, utils.KdmpConfigmapNamespace)
+		if err != nil {
+			logrus.Errorf("failed reading config map %v: %v", utils.KdmpConfigmapName, err)
+			logrus.Warnf("default to %s compression", utils.DefaultCompresion)
+			compressionType = utils.DefaultCompresion
+		} else {
+			compressionType = kdmpData.Data[compressionKey]
+		}
 		// start data transfer
-		id, err := startTransferJob(driver, srcPVCName, dataExport)
+		id, err := startTransferJob(driver, srcPVCName, compressionType, dataExport)
 		if err != nil {
 			msg := fmt.Sprintf("failed to start a data transfer job, dataexport [%v]: %v", dataExport.Name, err)
 			logrus.Warnf(msg)
@@ -1072,7 +1082,11 @@ func (c *Controller) checkGenericRestore(de *kdmpapi.DataExport) error {
 	return nil
 }
 
-func startTransferJob(drv drivers.Interface, srcPVCName string, dataExport *kdmpapi.DataExport) (string, error) {
+func startTransferJob(
+	drv drivers.Interface,
+	srcPVCName string,
+	compressionType string,
+	dataExport *kdmpapi.DataExport) (string, error) {
 	if drv == nil {
 		return "", fmt.Errorf("data transfer driver is not set")
 	}
@@ -1113,6 +1127,7 @@ func startTransferJob(drv drivers.Interface, srcPVCName string, dataExport *kdmp
 			drivers.WithDataExportName(dataExport.GetName()),
 			drivers.WithCertSecretName(drivers.CertSecretName),
 			drivers.WithCertSecretNamespace(dataExport.Spec.Source.Namespace),
+			drivers.WithCompressionType(compressionType),
 		)
 	case drivers.KopiaRestore:
 		return drv.StartJob(

--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -263,6 +263,12 @@ func jobFor(
 		"/data",
 	}, " ")
 
+	if jobOption.Compression != "" {
+		splitCmd := strings.Split(cmd, " ")
+		splitCmd = append(splitCmd, "--compression", jobOption.Compression)
+		cmd = strings.Join(splitCmd, " ")
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,

--- a/pkg/drivers/kopiabackup/kopiabackuplive.go
+++ b/pkg/drivers/kopiabackup/kopiabackuplive.go
@@ -55,6 +55,12 @@ func jobForLiveBackup(
 		backupPath,
 	}, " ")
 
+	if jobOption.Compression != "" {
+		splitCmd := strings.Split(cmd, " ")
+		splitCmd = append(splitCmd, "--compression", jobOption.Compression)
+		cmd = strings.Join(splitCmd, " ")
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,

--- a/pkg/drivers/options.go
+++ b/pkg/drivers/options.go
@@ -36,6 +36,7 @@ type JobOpts struct {
 	CertSecretNamespace         string
 	MaintenanceType             string
 	RepoPVCName                 string
+	Compression                 string
 }
 
 // WithBackupObjectName is job parameter.
@@ -308,6 +309,14 @@ func WithCertSecretNamespace(namespace string) JobOption {
 func WithMaintenanceType(maintenanceType string) JobOption {
 	return func(opts *JobOpts) error {
 		opts.MaintenanceType = maintenanceType
+		return nil
+	}
+}
+
+// WithCompressionType is job parameter.
+func WithCompressionType(compressionType string) JobOption {
+	return func(opts *JobOpts) error {
+		opts.Compression = compressionType
 		return nil
 	}
 }

--- a/pkg/drivers/utils/common.go
+++ b/pkg/drivers/utils/common.go
@@ -29,6 +29,12 @@ const (
 	TLSCertMountVol       = "tls-secret"
 	defaultTimeout        = 1 * time.Minute
 	progressCheckInterval = 5 * time.Second
+	// KdmpConfigmapName kdmp config map name
+	KdmpConfigmapName = "kdmp-config"
+	// KdmpConfigmapNamespace kdmp config map ns
+	KdmpConfigmapNamespace = "kube-system"
+	// DefaultCompresion default compression type
+	DefaultCompresion = "s2-parallel-8"
 )
 
 // SetupServiceAccount create a service account and bind it to a provided role.

--- a/pkg/kopia/command.go
+++ b/pkg/kopia/command.go
@@ -40,6 +40,8 @@ type Command struct {
 	MaintenanceOwner string
 	// DisableSsl option to disable ssl for s3
 	DisableSsl bool
+	// Compression to be used for backup
+	Compression string
 }
 
 // Executor interface defines APIs for implementing a command wrapper
@@ -316,6 +318,28 @@ func (c *Command) MaintenanceSetCmd() *exec.Cmd {
 		"set",
 		"--owner",
 		c.MaintenanceOwner,
+	}
+	argsSlice = append(argsSlice, c.Flags...)
+	// Get the cmd args
+	argsSlice = append(argsSlice, c.Args...)
+	cmd := exec.Command(baseCmd, argsSlice...)
+	if len(c.Env) > 0 {
+		cmd.Env = append(os.Environ(), c.Env...)
+	}
+	cmd.Dir = c.Dir
+
+	return cmd
+}
+
+// CompressionCmd returns os/exec.Cmd object for the kopia policy set
+func (c *Command) CompressionCmd() *exec.Cmd {
+	// Get all the flags
+	argsSlice := []string{
+		c.Name, // compression command
+		"set",
+		c.Path,
+		"--compression",
+		c.Compression,
 	}
 	argsSlice = append(argsSlice, c.Flags...)
 	// Get the cmd args

--- a/pkg/kopia/compression.go
+++ b/pkg/kopia/compression.go
@@ -1,0 +1,88 @@
+package kopia
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+
+	cmdexec "github.com/portworx/kdmp/pkg/executor"
+	"github.com/sirupsen/logrus"
+)
+
+type compressionExecutor struct {
+	cmd       *Command
+	execCmd   *exec.Cmd
+	outBuf    *bytes.Buffer
+	errBuf    *bytes.Buffer
+	lastError error
+	isRunning bool
+}
+
+// GetCompressionCommand returns a wrapper over the kopia policy set
+func GetCompressionCommand(path, compression string) (*Command, error) {
+	if path == "" {
+		return nil, fmt.Errorf("path name cannot be empty")
+	}
+	return &Command{
+		Name:        "policy",
+		Path:        path,
+		Compression: compression,
+	}, nil
+}
+
+// NewCompressionExecutor returns an instance of Executor that can be used for
+// running a kopia policy set command
+func NewCompressionExecutor(cmd *Command) Executor {
+	return &compressionExecutor{
+		cmd:    cmd,
+		outBuf: new(bytes.Buffer),
+		errBuf: new(bytes.Buffer),
+	}
+}
+
+func (c *compressionExecutor) Run() error {
+	c.execCmd = c.cmd.CompressionCmd()
+	c.execCmd.Stdout = c.outBuf
+	c.execCmd.Stderr = c.errBuf
+
+	if err := c.execCmd.Start(); err != nil {
+		c.lastError = err
+		return err
+	}
+	c.isRunning = true
+	go func() {
+		err := c.execCmd.Wait()
+		if err != nil {
+			c.lastError = fmt.Errorf("failed to run the kopia compression setting command: %v"+
+				" stdout: %v stderr: %v", err, c.outBuf.String(), c.errBuf.String())
+			logrus.Errorf("%v", c.lastError)
+			return
+		}
+		c.isRunning = false
+	}()
+
+	return nil
+}
+
+func (c *compressionExecutor) Status() (*cmdexec.Status, error) {
+	if c.lastError != nil {
+		fmt.Fprintln(os.Stderr, c.errBuf.String())
+		return &cmdexec.Status{
+			LastKnownError: c.lastError,
+			Done:           true,
+		}, nil
+	}
+
+	if c.isRunning {
+		return &cmdexec.Status{
+			Done:           false,
+			LastKnownError: nil,
+		}, nil
+	}
+
+	return &cmdexec.Status{
+		Done: true,
+	}, nil
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added support for compression during backup
- Compression type can be set through kdmp-config map

**Which issue(s) this PR fixes** (optional)
PB-1984

**Special notes for your reviewer**:

Manual test
Took a backup of mysql app running
Can be the actual size of 115>B getting reduced to 3.5MB after compression in objectsore

Logs to show compression being set
```
[root@prashanth-winter-fighter-2 kdmp]# k logs -f backup-3fdcd03-5405c0d-mysql-c4sfs -nmysql
+ /kopiaexecutor backup --volume-backup-name backup-3fdcd03-5405c0d-mysql --credentials backup-3fdcd03-5405c0d-mysql --backup-location pk-aws-bl-72bb31e --backup-location-namespace mysql --backup-namespace mysql --repository mysql-mysql-proxy-data --source-path-glob /data/kubernetes.io~portworx-volume/pvc-5405c0d0-3df5-40d1-a29e-64095db4e437 --compression s2-parallel-8
time="2021-10-31T17:50:05Z" level=info msg="line 55 compression: s2-parallel-8"
time="2021-10-31T17:50:05Z" level=info msg="type: s3"
time="2021-10-31T17:50:06Z" level=info msg="kopia.repository doesn't exists"
time="2021-10-31T17:50:06Z" level=info msg="Repository creation started"
2021/10/31 17:50:06 repo create status not available Next retry in: 5s
2021/10/31 17:50:11 repo create status not available Next retry in: 5s
2021/10/31 17:50:16 repo create status not available Next retry in: 5s
time="2021-10-31T17:50:21Z" level=info msg="Repository creation successful"
time="2021-10-31T17:50:21Z" level=info msg="Setting global policy"
time="2021-10-31T17:50:21Z" level=info msg="Global policy set successfully"
time="2021-10-31T17:50:21Z" level=info msg="Repository connect started"
2021/10/31 17:50:21 repository connect status not available Next retry in: 5s
2021/10/31 17:50:26 repository connect status not available Next retry in: 5s
time="2021-10-31T17:50:31Z" level=info msg="kopia repo connect successful .."
time="2021-10-31T17:50:31Z" level=info msg="Compression started"
time="2021-10-31T17:50:31Z" level=info msg="line 442 compressionCmd: &{Name:policy Path:/data/kubernetes.io~portworx-volume/pvc-5405c0d0-3df5-40d1-a29e-64095db4e437 RepositoryName: Dir: Args:[] Flags:[] Env:[] Password: Provider: SnapshotID: MaintenanceOwner: DisableSsl:false Compression:s2-parallel-8}"
time="2021-10-31T17:50:31Z" level=info msg="line 331 cmd: /usr/bin/kopia policy set /data/kubernetes.io~portworx-volume/pvc-5405c0d0-3df5-40d1-a29e-64095db4e437 --compression s2-parallel-8"
time="2021-10-31T17:50:36Z" level=info msg="compression successful"
time="2021-10-31T17:50:36Z" level=info msg="Backup started"
time="2021-10-31T17:50:46Z" level=info msg="Backup successful"

```

Screen shot of backup size
![Screenshot 2021-10-31 at 11 18 21 PM (2)](https://user-images.githubusercontent.com/51692473/139596783-655e9bf3-4f74-4c02-9588-843b294aa933.png)
![Screenshot 2021-10-31 at 11 18 30 PM (2)](https://user-images.githubusercontent.com/51692473/139596786-c4a09c6a-c5ac-48c4-9505-01c1b1349986.png)
