### PR TITLE
[STOR-551]: pvc creation logic is moved to kdmp reconciler in restore path.

### DIFF
--- a/pkg/apis/kdmp/v1alpha1/dataexport.go
+++ b/pkg/apis/kdmp/v1alpha1/dataexport.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -112,17 +113,19 @@ type DataExportObjectReference struct {
 
 // ExportStatus indicates a current state of the data transfer.
 type ExportStatus struct {
-	Stage                DataExportStage  `json:"stage,omitempty"`
-	Status               DataExportStatus `json:"status,omitempty"`
-	Reason               string           `json:"reason,omitempty"`
-	SnapshotID           string           `json:"snapshotID,omitempty"`
-	SnapshotNamespace    string           `json:"snapshotNamespace,omitempty"`
-	SnapshotPVCName      string           `json:"snapshotPVCName,omitempty"`
-	SnapshotPVCNamespace string           `json:"snapshotPVCNamespace,omitempty"`
-	TransferID           string           `json:"transferID,omitempty"`
-	ProgressPercentage   int              `json:"progressPercentage,omitempty"`
-	Size                 uint64           `json:"size,omitempty"`
-	VolumeSnapshot       string           `json:"volumeSnapshot,omitempty"`
+	Stage                DataExportStage           `json:"stage,omitempty"`
+	Status               DataExportStatus          `json:"status,omitempty"`
+	Reason               string                    `json:"reason,omitempty"`
+	SnapshotID           string                    `json:"snapshotID,omitempty"`
+	SnapshotNamespace    string                    `json:"snapshotNamespace,omitempty"`
+	SnapshotPVCName      string                    `json:"snapshotPVCName,omitempty"`
+	SnapshotPVCNamespace string                    `json:"snapshotPVCNamespace,omitempty"`
+	TransferID           string                    `json:"transferID,omitempty"`
+	ProgressPercentage   int                       `json:"progressPercentage,omitempty"`
+	Size                 uint64                    `json:"size,omitempty"`
+	VolumeSnapshot       string                    `json:"volumeSnapshot,omitempty"`
+	RestorePVC           *v1.PersistentVolumeClaim `json:"restorePVC,omitempty"`
+	LocalSnapshotRestore bool                      `json:"localSnapshotRestore,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -243,6 +243,31 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 				}
 				return false, c.updateStatus(dataExport, data)
 			}
+
+			// Create the pvc from the spec provided in the dataexport CR
+			pvcSpec := dataExport.Status.RestorePVC
+			_, err = c.createPVC(dataExport)
+			if err != nil {
+				msg := fmt.Sprintf("Error creating pvc %s/%s for restore: %v", pvcSpec.Namespace, pvcSpec.Name, err)
+				logrus.Errorf(msg)
+				data := updateDataExportDetail{
+					status: kdmpapi.DataExportStatusFailed,
+					reason: msg,
+				}
+				return false, c.updateStatus(dataExport, data)
+			}
+
+			_, err = checkPVC(dataExport.Spec.Destination, true)
+			if err != nil {
+				msg := fmt.Sprintf("Destination pvc %s/%s is not bound yet: %v", pvcSpec.Namespace, pvcSpec.Name, err)
+				logrus.Errorf(msg)
+				data := updateDataExportDetail{
+					status: kdmpapi.DataExportStatusFailed,
+					reason: msg,
+				}
+				return false, c.updateStatus(dataExport, data)
+			}
+
 			// This will create a unique secret per PVC being restored
 			// For restore create the secret in the ns where PVC is referenced
 			err = CreateCredentialsSecret(
@@ -994,6 +1019,18 @@ func (c *Controller) restoreSnapshot(ctx context.Context, snapshotDriver snapsho
 	return pvc, nil
 }
 
+func (c *Controller) createPVC(dataExport *kdmpapi.DataExport) (*corev1.PersistentVolumeClaim, error) {
+	pvc := dataExport.Status.RestorePVC
+	newPVC, err := core.Instance().CreatePersistentVolumeClaim(pvc)
+	if err != nil {
+		if k8sErrors.IsAlreadyExists(err) {
+			return pvc, nil
+		}
+		return nil, fmt.Errorf("failed to create PVC %s: %s", pvc.Name, err.Error())
+	}
+	return newPVC, nil
+}
+
 func (c *Controller) checkClaims(de *kdmpapi.DataExport) error {
 	if !hasSnapshotStage(de) && de.Spec.Source.Namespace != de.Spec.Destination.Namespace {
 		return fmt.Errorf("source and destination volume claims should be in the same namespace if no snapshot class is provided")
@@ -1064,9 +1101,6 @@ func (c *Controller) checkGenericRestore(de *kdmpapi.DataExport) error {
 
 	if !isPVCRef(de.Spec.Destination) && !isAPIVersionKindNotSetRef(de.Spec.Destination) {
 		return fmt.Errorf("destination is expected to be PersistentVolumeClaim")
-	}
-	if _, err := checkPVC(de.Spec.Destination, true); err != nil {
-		return fmt.Errorf("destination: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
signed-off-by: Diptiranjan

** Test**
<img width="1789" alt="Screenshot 2021-11-03 at 8 36 19 PM" src="https://user-images.githubusercontent.com/51692470/140086791-d6c270d4-1771-417d-8f2b-e51372521c48.png">

