### PR TITLE
Handle default snapshot classes

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -587,6 +587,10 @@ func (c *Controller) getSnapshotDriverName(dataExport *kdmpapi.DataExport) (stri
 	if len(dataExport.Spec.SnapshotStorageClass) == 0 {
 		return "", fmt.Errorf("snapshot storage class not provided")
 	}
+	if dataExport.Spec.SnapshotStorageClass == "default" ||
+		dataExport.Spec.SnapshotStorageClass == "Default" {
+		return csiProvider, nil
+	}
 	// Check if snapshot class is a CSI snapshot class
 	config, err := rest.InClusterConfig()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Treat a snapshot class name provided as "default" or "Default" specifically for CSI snapshot provider.
- If such a snapshot class is detected then assume that it is the CSI snapshotter provider.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

