### PR TITLE
[PB-2026]: Restore size should be shown if restore happens from local snapshot for csi volumes in generic backup.

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -1024,9 +1024,12 @@ func (c *Controller) stageLocalSnapshotRestoreInProgress(ctx context.Context, da
 		return false, c.updateStatus(dataExport, data)
 	}
 
+	msg := fmt.Sprintf("Volume restore from local snapshot for volumebackup %s in namespace %s is successful", dataExport.Spec.Source.Name, dataExport.Spec.Source.Namespace)
+	logrus.Debugf(msg)
 	data := updateDataExportDetail{
 		status: kdmpapi.DataExportStatusSuccessful,
-		reason: restoreInfo.Reason,
+		reason: msg,
+		size:   restoreInfo.Size,
 	}
 	return true, c.updateStatus(dataExport, data)
 


### PR DESCRIPTION
Signed-off-by: Diptiranjan

**What this PR does / why we need it**:
Volume info should show restore object even if it is restored from local snapshots.

Below `2026` restore is the restore from the local snapshot for a FA volume.

<img width="1786" alt="Screenshot 2021-11-16 at 10 52 02 PM" src="https://user-images.githubusercontent.com/51692470/142035036-a2f0597d-0f9d-4929-a238-b3333476cd76.png">

