### PR TITLE
PB-2042: Fixed backup failure retry due when fatalerror count is encountered

### DIFF
--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -124,6 +124,8 @@ type JobStatus struct {
 	ProgressPercents float64
 	State            JobState
 	Reason           string
+	// RestartCount holds container restart count of job pod
+	RestartCount int32
 }
 
 // IsTransferCompleted allows to check transfer status.

--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -189,7 +189,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	fn := "JobStatus"
 	namespace, name, err := utils.ParseJobID(id)
 	if err != nil {
-		return utils.ToJobStatus(0, err.Error()), nil
+		return utils.ToJobStatus(0, err.Error(), 0), nil
 	}
 
 	job, err := batch.Instance().GetJob(name, namespace)
@@ -198,15 +198,21 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
+	restartCount, err := utils.FetchJobContainerRestartCount(job)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to get restart count for job  %s/%s job: %v", namespace, name, err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
 	jobErr, nodeErr := utils.IsJobOrNodeFailed(job)
 	var errMsg string
 	if jobErr {
 		errMsg = fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
-		return utils.ToJobStatus(0, errMsg), nil
+		return utils.ToJobStatus(0, errMsg, restartCount), nil
 	}
 	if nodeErr {
 		errMsg = fmt.Sprintf("Node [%v] on which job [%v/%v] schedules is NotReady", job.Spec.Template.Spec.NodeName, namespace, name)
-		return utils.ToJobStatus(0, errMsg), nil
+		return utils.ToJobStatus(0, errMsg, restartCount), nil
 	}
 
 	vb, err := kdmpops.Instance().GetVolumeBackup(context.Background(), name, namespace)
@@ -214,7 +220,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		if apierrors.IsNotFound(err) {
 			if utils.IsJobPending(job) {
 				logrus.Warnf("backup job %s is in pending state", job.Name)
-				return utils.ToJobStatus(0, ""), nil
+				return utils.ToJobStatus(0, "", restartCount), nil
 			}
 		}
 		errMsg := fmt.Sprintf("failed to fetch volumebackup %s/%s status: %v", namespace, name, err)
@@ -222,7 +228,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		return nil, fmt.Errorf(errMsg)
 	}
 
-	return utils.ToJobStatus(vb.Status.ProgressPercentage, vb.Status.LastKnownError), nil
+	return utils.ToJobStatus(vb.Status.ProgressPercentage, vb.Status.LastKnownError, restartCount), nil
 }
 
 func (d Driver) validate(o drivers.JobOpts) error {
@@ -279,6 +285,7 @@ func jobFor(
 			Labels: labels,
 		},
 		Spec: batchv1.JobSpec{
+			BackoffLimit: &utils.JobPodBackOffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/pkg/drivers/kopiabackup/kopiabackuplive.go
+++ b/pkg/drivers/kopiabackup/kopiabackuplive.go
@@ -71,6 +71,7 @@ func jobForLiveBackup(
 			Labels: labels,
 		},
 		Spec: batchv1.JobSpec{
+			BackoffLimit: &utils.JobPodBackOffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -121,7 +121,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	fn := "JobStatus"
 	namespace, name, err := utils.ParseJobID(id)
 	if err != nil {
-		return utils.ToJobStatus(0, err.Error()), nil
+		return utils.ToJobStatus(0, err.Error(), 0), nil
 	}
 
 	job, err := batch.Instance().GetJob(name, namespace)
@@ -130,14 +130,21 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
+	restartCount, err := utils.FetchJobContainerRestartCount(job)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to get restart count for job  %s/%s job: %v", namespace, name, err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
 	if utils.IsJobFailed(job) {
 		errMsg := fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
-		return utils.ToJobStatus(0, errMsg), nil
+		return utils.ToJobStatus(0, errMsg, restartCount), nil
 	}
 	if utils.IsJobCompleted(job) {
-		return utils.ToJobStatus(drivers.TransferProgressCompleted, ""), nil
+		return utils.ToJobStatus(drivers.TransferProgressCompleted, "", restartCount), nil
 	}
-	return utils.ToJobStatus(0, ""), nil
+	return utils.ToJobStatus(0, "", restartCount), nil
 }
 
 func (d Driver) validate(o drivers.JobOpts) error {
@@ -177,6 +184,7 @@ func jobFor(
 			Labels: labels,
 		},
 		Spec: batchv1.JobSpec{
+			BackoffLimit: &utils.JobPodBackOffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -102,30 +102,38 @@ func (d Driver) DeleteJob(id string) error {
 
 // JobStatus returns a progress status for a data transfer.
 func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
+	fn := "JobStatus:"
 	namespace, name, err := utils.ParseJobID(id)
 	if err != nil {
-		return utils.ToJobStatus(0, err.Error()), nil
+		return utils.ToJobStatus(0, err.Error(), 0), nil
 	}
 
 	job, err := batch.Instance().GetJob(name, namespace)
 	if err != nil {
 		return nil, err
 	}
+	restartCount, err := utils.FetchJobContainerRestartCount(job)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to get restart count for job  %s/%s job: %v", namespace, name, err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
 	if utils.IsJobFailed(job) {
 		errMsg := fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
-		return utils.ToJobStatus(0, errMsg), nil
+		return utils.ToJobStatus(0, errMsg, restartCount), nil
 	}
 	if utils.IsJobPending(job) {
 		logrus.Warnf("restore job %s is in pending state", job.Name)
-		return utils.ToJobStatus(0, ""), nil
+		return utils.ToJobStatus(0, "", restartCount), nil
 	}
 
 	if !utils.IsJobCompleted(job) {
 		// TODO: update progress
-		return utils.ToJobStatus(0, ""), nil
+		return utils.ToJobStatus(0, "", restartCount), nil
 	}
 
-	return utils.ToJobStatus(drivers.TransferProgressCompleted, ""), nil
+	return utils.ToJobStatus(drivers.TransferProgressCompleted, "", restartCount), nil
 }
 
 func (d Driver) validate(o drivers.JobOpts) error {
@@ -188,6 +196,7 @@ func jobFor(
 			Labels: labels,
 		},
 		Spec: batchv1.JobSpec{
+			BackoffLimit: &utils.JobPodBackOffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/pkg/drivers/resticbackup/resticbackuplive.go
+++ b/pkg/drivers/resticbackup/resticbackuplive.go
@@ -65,6 +65,7 @@ func jobForLiveBackup(
 			Labels:    labels,
 		},
 		Spec: batchv1.JobSpec{
+			BackoffLimit: &utils.JobPodBackOffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/pkg/drivers/resticrestore/resticrestore.go
+++ b/pkg/drivers/resticrestore/resticrestore.go
@@ -103,23 +103,30 @@ func (d Driver) DeleteJob(id string) error {
 func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	namespace, name, err := utils.ParseJobID(id)
 	if err != nil {
-		return utils.ToJobStatus(0, err.Error()), nil
+		return utils.ToJobStatus(0, err.Error(), 0), nil
 	}
 
 	job, err := batch.Instance().GetJob(name, namespace)
 	if err != nil {
 		return nil, err
 	}
+
+	restartCount, err := utils.FetchJobContainerRestartCount(job)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to rget estart count for job  %s/%s job: %v", namespace, name, err)
+		return nil, fmt.Errorf(errMsg)
+	}
+
 	if utils.IsJobFailed(job) {
 		errMsg := fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
-		return utils.ToJobStatus(0, errMsg), nil
+		return utils.ToJobStatus(0, errMsg, restartCount), nil
 	}
 	if !utils.IsJobCompleted(job) {
 		// TODO: update progress
-		return utils.ToJobStatus(0, ""), nil
+		return utils.ToJobStatus(0, "", restartCount), nil
 	}
 
-	return utils.ToJobStatus(drivers.TransferProgressCompleted, ""), nil
+	return utils.ToJobStatus(drivers.TransferProgressCompleted, "", restartCount), nil
 }
 
 func (d Driver) validate(o drivers.JobOpts) error {
@@ -174,6 +181,7 @@ func jobFor(
 			Labels:    labels,
 		},
 		Spec: batchv1.JobSpec{
+			BackoffLimit: &utils.JobPodBackOffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/pkg/drivers/rsync/rsync.go
+++ b/pkg/drivers/rsync/rsync.go
@@ -70,24 +70,31 @@ func (d Driver) DeleteJob(id string) error {
 func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	namespace, name, err := utils.ParseJobID(id)
 	if err != nil {
-		return utils.ToJobStatus(0, err.Error()), nil
+		return utils.ToJobStatus(0, err.Error(), 0), nil
 	}
 
 	job, err := batch.Instance().GetJob(name, namespace)
 	if err != nil {
 		return nil, err
 	}
+
+	restartCount, err := utils.FetchJobContainerRestartCount(job)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to get restart count for job  %s/%s job: %v", namespace, name, err)
+		return nil, fmt.Errorf(errMsg)
+	}
+
 	if utils.IsJobFailed(job) {
 		errMsg := fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
-		return utils.ToJobStatus(0, errMsg), nil
+		return utils.ToJobStatus(0, errMsg, restartCount), nil
 	}
 
 	if !utils.IsJobCompleted(job) {
 		// TODO: update progress
-		return utils.ToJobStatus(0, ""), nil
+		return utils.ToJobStatus(0, "", restartCount), nil
 	}
 
-	return utils.ToJobStatus(drivers.TransferProgressCompleted, ""), nil
+	return utils.ToJobStatus(drivers.TransferProgressCompleted, "", 0), nil
 }
 
 func (d Driver) validate(o drivers.JobOpts) error {
@@ -123,6 +130,7 @@ func jobFor(srcVol, dstVol, namespace string, labels map[string]string) (*batchv
 			Labels:    labels,
 		},
 		Spec: batchv1.JobSpec{
+			BackoffLimit: &utils.JobPodBackOffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/pkg/drivers/utils/common.go
+++ b/pkg/drivers/utils/common.go
@@ -37,6 +37,11 @@ const (
 	DefaultCompresion = "s2-parallel-8"
 )
 
+var (
+	// JobPodBackOffLimit backofflimit for the job
+	JobPodBackOffLimit = int32(4)
+)
+
 // SetupServiceAccount create a service account and bind it to a provided role.
 func SetupServiceAccount(name, namespace string, role *rbacv1.Role) error {
 	if role != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
```
  PB-2042: Fixed backup failure retry due when fatalerror count is encountered
    - As part of a reconciler, before the error is reported in stage In-progress, the reconciler will check
      if the job has exhausted pod retires amount to backof limit.
    - If the pod has restarted this many times, the job will be marked as failed and moved to
      cleanup stage.
```

**Which issue(s) this PR fixes** (optional)
PB-2042

**Special notes for your reviewer**:

Manual test
1. Simulated error by pointing a wrong backuploation
2. Trigerred a backup
3.  Checked the job pod was restarted till backoff limit is reached and no resources were deleted
4.  After exhausting backoff limit, all resources were deleted and backup marked as failure.
5
