### PR TITLE
pb-2049: Added pod pending phase check in the buildJob of kopiabackup

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -189,6 +189,16 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 			return true, c.updateStatus(dataExport, data)
 		}
 
+		if dataExport.Status.Status == kdmpapi.DataExportStatusFailed {
+			// set to the next stage
+			data := updateDataExportDetail{
+				stage:  kdmpapi.DataExportStageCleanup,
+				status: dataExport.Status.Status,
+				reason: "",
+			}
+			return false, c.updateStatus(dataExport, data)
+		}
+
 		// use snapshot pvc in the dst namespace if it's available
 		srcPVCName := dataExport.Spec.Source.Name
 		if dataExport.Status.SnapshotPVCName != "" {
@@ -1474,42 +1484,54 @@ func waitForPVCBound(in kdmpapi.DataExportObjectReference, checkMounts bool) (*c
 }
 
 func checkPVCIgnoringJobMounts(in kdmpapi.DataExportObjectReference, expectedMountJob string) (*corev1.PersistentVolumeClaim, error) {
-	if err := checkNameNamespace(in); err != nil {
-		return nil, err
-	}
-	pvc, err := core.Instance().GetPersistentVolumeClaim(in.Name, in.Namespace)
-	if err != nil {
-		return nil, err
-	}
-	var sc *storagev1.StorageClass
-	storageClassName := k8shelper.GetPersistentVolumeClaimClass(pvc)
-	if storageClassName != "" {
-		sc, err = storage.Instance().GetStorageClass(storageClassName)
-		if err != nil {
-			return nil, err
+	var pvc *corev1.PersistentVolumeClaim
+	var checkErr error
+	checkTask := func() (interface{}, bool, error) {
+		if checkErr := checkNameNamespace(in); checkErr != nil {
+			return "", true, checkErr
 		}
-		logrus.Debugf("checkPVCIgnoringJobMounts: pvc name %v - storage class VolumeBindingMode %v", pvc.Name, *sc.VolumeBindingMode)
-	}
-	if *sc.VolumeBindingMode != storagev1.VolumeBindingWaitForFirstConsumer {
-		// wait for pvc to get bound
-		pvc, err = waitForPVCBound(in, true)
-		if err != nil {
-			return nil, err
+		pvc, checkErr = core.Instance().GetPersistentVolumeClaim(in.Name, in.Namespace)
+		if checkErr != nil {
+			return "", true, checkErr
 		}
-	}
-
-	pods, err := core.Instance().GetPodsUsingPVC(pvc.Name, pvc.Namespace)
-	if err != nil {
-		return nil, fmt.Errorf("get mounted pods: %v", err)
-	}
-
-	if len(pods) > 0 {
-		for _, pod := range pods {
-			if podBelongsToJob(pod, expectedMountJob, pvc.Namespace) {
-				return pvc, nil
+		var sc *storagev1.StorageClass
+		storageClassName := k8shelper.GetPersistentVolumeClaimClass(pvc)
+		if storageClassName != "" {
+			sc, checkErr = storage.Instance().GetStorageClass(storageClassName)
+			if checkErr != nil {
+				return "", true, checkErr
+			}
+			logrus.Debugf("checkPVCIgnoringJobMounts: pvc name %v - storage class VolumeBindingMode %v", pvc.Name, *sc.VolumeBindingMode)
+		}
+		if *sc.VolumeBindingMode != storagev1.VolumeBindingWaitForFirstConsumer {
+			// wait for pvc to get bound
+			pvc, checkErr = waitForPVCBound(in, true)
+			if checkErr != nil {
+				return "", true, checkErr
 			}
 		}
-		return nil, fmt.Errorf("mounted to %v pods", toPodNames(pods))
+
+		pods, checkErr := core.Instance().GetPodsUsingPVC(pvc.Name, pvc.Namespace)
+		if checkErr != nil {
+			return "", true, fmt.Errorf("get mounted pods: %v", checkErr)
+		}
+
+		if len(pods) > 0 {
+			for _, pod := range pods {
+				if podBelongsToJob(pod, expectedMountJob, pvc.Namespace) {
+					return "", false, nil
+				}
+			}
+			checkErr = fmt.Errorf("mounted to %v pods", toPodNames(pods))
+			return "", false, checkErr
+		}
+		return "", false, nil
+	}
+	if _, err := task.DoRetryWithTimeout(checkTask, defaultTimeout, progressCheckInterval); err != nil {
+		errMsg := fmt.Sprintf("max retries done, failed to check the PVC status in dataexport %v/%v: %v", in.Namespace, in.Name, checkErr)
+		logrus.Errorf("%v", errMsg)
+		// Exhausted all retries, fail the CR
+		return nil, fmt.Errorf("%v", errMsg)
 	}
 	return pvc, nil
 }

--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -402,9 +402,14 @@ func buildJob(jobName string, jobOptions drivers.JobOpts) (*batchv1.Job, error) 
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
-
 	// run a "live" backup if a pvc is mounted (mount a kubelet directory with pod volumes)
 	if len(pods) > 0 {
+		logrus.Debugf("buildJob: pod %v phase %v pvc: %v/%v", pods[0].Name, pods[0].Status.Phase, jobOptions.Namespace, jobOptions.SourcePVCName)
+		if pods[0].Status.Phase == corev1.PodPending {
+			errMsg := fmt.Sprintf("pods %v is using pvc %v/%v but it is in pending state, backup is not possible", pods[0].Name, jobOptions.Namespace, jobOptions.SourcePVCName)
+			logrus.Errorf("%s: %v", fn, errMsg)
+			return nil, fmt.Errorf(errMsg)
+		}
 		return jobForLiveBackup(
 			jobOptions,
 			jobName,


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-2049: Added pod pending phase check in the buildJob of kopiabackup

        - Made checkPVCIgnoringJobMounts to be retried in the case of
          failure.
        - Will jump to cleanup stage when we hit failure in Transfer
          schedule stage
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-2049

**Special notes for your reviewer**:
Testing:
Triggered a backup on the namespace which had pending pods and checked that it fails.
![Screenshot 2021-11-19 at 12 52 42 PM](https://user-images.githubusercontent.com/52188641/142582006-0c5b984f-5ef2-49dd-a579-ba3fe3a27d88.png)

