### PR TITLE
PB-2073 Replacing pod restart count decission with job spec status

### DIFF
--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -1,6 +1,9 @@
 package drivers
 
-import "fmt"
+import (
+	"fmt"
+	batchv1 "k8s.io/api/batch/v1"
+)
 
 // Known drivers.
 const (
@@ -124,8 +127,7 @@ type JobStatus struct {
 	ProgressPercents float64
 	State            JobState
 	Reason           string
-	// RestartCount holds container restart count of job pod
-	RestartCount int32
+	Status           batchv1.JobConditionType
 }
 
 // IsTransferCompleted allows to check transfer status.

--- a/pkg/drivers/kopiamaintenance/kopiamaintenance.go
+++ b/pkg/drivers/kopiamaintenance/kopiamaintenance.go
@@ -94,7 +94,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	fn := "JobStatus"
 	namespace, name, err := utils.ParseJobID(id)
 	if err != nil {
-		return utils.ToJobStatus(0, err.Error(), 0), nil
+		return utils.ToJobStatus(0, err.Error(), batchv1.JobConditionType("")), nil
 	}
 
 	job, err := batch.Instance().GetJob(name, namespace)
@@ -103,8 +103,11 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
+	var jobStatus batchv1.JobConditionType
+	if len(job.Status.Conditions) != 0 {
+		jobStatus = job.Status.Conditions[0].Type
 
-	restartCount, err := utils.FetchJobContainerRestartCount(job)
+	}
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to get restart count for job  %s/%s job: %v", namespace, name, err)
 		logrus.Errorf("%s: %v", fn, errMsg)
@@ -113,12 +116,12 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 
 	if utils.IsJobFailed(job) {
 		errMsg := fmt.Sprintf("check maintenance [%s/%s] job for details: %s", namespace, name, drivers.ErrJobFailed)
-		return utils.ToJobStatus(0, errMsg, restartCount), nil
+		return utils.ToJobStatus(0, errMsg, jobStatus), nil
 	}
 	if utils.IsJobCompleted(job) {
-		return utils.ToJobStatus(drivers.TransferProgressCompleted, "", restartCount), nil
+		return utils.ToJobStatus(drivers.TransferProgressCompleted, "", jobStatus), nil
 	}
-	return utils.ToJobStatus(0, "", restartCount), nil
+	return utils.ToJobStatus(0, "", jobStatus), nil
 }
 
 func (d Driver) validate(o drivers.JobOpts) error {

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -105,14 +105,18 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	fn := "JobStatus:"
 	namespace, name, err := utils.ParseJobID(id)
 	if err != nil {
-		return utils.ToJobStatus(0, err.Error(), 0), nil
+		return utils.ToJobStatus(0, err.Error(), batchv1.JobConditionType("")), nil
 	}
 
 	job, err := batch.Instance().GetJob(name, namespace)
 	if err != nil {
 		return nil, err
 	}
-	restartCount, err := utils.FetchJobContainerRestartCount(job)
+	var jobStatus batchv1.JobConditionType
+	if len(job.Status.Conditions) != 0 {
+		jobStatus = job.Status.Conditions[0].Type
+
+	}
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to get restart count for job  %s/%s job: %v", namespace, name, err)
 		logrus.Errorf("%s: %v", fn, errMsg)
@@ -121,19 +125,19 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 
 	if utils.IsJobFailed(job) {
 		errMsg := fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
-		return utils.ToJobStatus(0, errMsg, restartCount), nil
+		return utils.ToJobStatus(0, errMsg, jobStatus), nil
 	}
 	if utils.IsJobPending(job) {
 		logrus.Warnf("restore job %s is in pending state", job.Name)
-		return utils.ToJobStatus(0, "", restartCount), nil
+		return utils.ToJobStatus(0, "", jobStatus), nil
 	}
 
 	if !utils.IsJobCompleted(job) {
 		// TODO: update progress
-		return utils.ToJobStatus(0, "", restartCount), nil
+		return utils.ToJobStatus(0, "", jobStatus), nil
 	}
 
-	return utils.ToJobStatus(drivers.TransferProgressCompleted, "", restartCount), nil
+	return utils.ToJobStatus(drivers.TransferProgressCompleted, "", jobStatus), nil
 }
 
 func (d Driver) validate(o drivers.JobOpts) error {

--- a/pkg/drivers/rsync/rsync.go
+++ b/pkg/drivers/rsync/rsync.go
@@ -70,15 +70,18 @@ func (d Driver) DeleteJob(id string) error {
 func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	namespace, name, err := utils.ParseJobID(id)
 	if err != nil {
-		return utils.ToJobStatus(0, err.Error(), 0), nil
+		return utils.ToJobStatus(0, err.Error(), batchv1.JobConditionType("")), nil
 	}
 
 	job, err := batch.Instance().GetJob(name, namespace)
 	if err != nil {
 		return nil, err
 	}
+	var jobStatus batchv1.JobConditionType
+	if len(job.Status.Conditions) != 0 {
+		jobStatus = job.Status.Conditions[0].Type
 
-	restartCount, err := utils.FetchJobContainerRestartCount(job)
+	}
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to get restart count for job  %s/%s job: %v", namespace, name, err)
 		return nil, fmt.Errorf(errMsg)
@@ -86,15 +89,15 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 
 	if utils.IsJobFailed(job) {
 		errMsg := fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
-		return utils.ToJobStatus(0, errMsg, restartCount), nil
+		return utils.ToJobStatus(0, errMsg, jobStatus), nil
 	}
 
 	if !utils.IsJobCompleted(job) {
 		// TODO: update progress
-		return utils.ToJobStatus(0, "", restartCount), nil
+		return utils.ToJobStatus(0, "", jobStatus), nil
 	}
 
-	return utils.ToJobStatus(drivers.TransferProgressCompleted, "", 0), nil
+	return utils.ToJobStatus(drivers.TransferProgressCompleted, "", batchv1.JobConditionType("")), nil
 }
 
 func (d Driver) validate(o drivers.JobOpts) error {

--- a/pkg/drivers/utils/utils.go
+++ b/pkg/drivers/utils/utils.go
@@ -140,12 +140,12 @@ func FetchJobContainerRestartCount(j *batchv1.Job) (int32, error) {
 }
 
 // ToJobStatus returns a job status for provided parameters.
-func ToJobStatus(progress float64, errMsg string, retartCount int32) *drivers.JobStatus {
+func ToJobStatus(progress float64, errMsg string, jobStatus batchv1.JobConditionType) *drivers.JobStatus {
 	if len(errMsg) > 0 {
 		return &drivers.JobStatus{
-			State:        drivers.JobStateFailed,
-			Reason:       errMsg,
-			RestartCount: retartCount,
+			State:  drivers.JobStateFailed,
+			Reason: errMsg,
+			Status: jobStatus,
 		}
 	}
 
@@ -153,14 +153,14 @@ func ToJobStatus(progress float64, errMsg string, retartCount int32) *drivers.Jo
 		return &drivers.JobStatus{
 			State:            drivers.JobStateCompleted,
 			ProgressPercents: progress,
-			RestartCount:     retartCount,
+			Status:           jobStatus,
 		}
 	}
 
 	return &drivers.JobStatus{
 		State:            drivers.JobStateInProgress,
 		ProgressPercents: progress,
-		RestartCount:     retartCount,
+		Status:           jobStatus,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- In some cases, once backOff limit is kicked in looks like k8s is not giving was restart count which will be assumed as zero. With this, a backup would be in-progress forever
- Instead of reading the pod restart count, changed the logic to read the job spec and if it has been marked as a failure for whatever reason,  DE CR cleanup would be triggered.

**Which issue(s) this PR fixes** (optional)
PB-2073

**Special notes for your reviewer**:

**Manual test**
Case 1
- Trigerred backup of 3 PVC
- Killed one backup pod continuously till backupoff limit is reached
- Eventually, the entire backup is marked as failed.

Case 2:
- Trigerred backup of 3 PVC
- Killed one backup pod only once so that job tries to restart it next time
- Eventually, the entire backup succeeds
