### PR TITLE
pb-2075: Corrected the error handling in checking the PVC bound status.

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -67,7 +67,7 @@ const (
 	pvcNameLenLimit       = 247
 	volumeinitialDelay    = 2 * time.Second
 	volumeFactor          = 1.5
-	volumeSteps           = 20
+	volumeSteps           = 15
 	defaultTimeout        = 1 * time.Minute
 	progressCheckInterval = 5 * time.Second
 	compressionKey        = "KDMP_COMPRESSION"
@@ -1501,8 +1501,8 @@ func waitForPVCBound(in kdmpapi.DataExportObjectReference, checkMounts bool) (*c
 	})
 
 	if wErr != nil {
-		logrus.Errorf("%v", err)
-		return nil, err
+		logrus.Errorf("%v", wErr)
+		return nil, wErr
 	}
 	return pvc, nil
 }
@@ -1552,7 +1552,7 @@ func checkPVCIgnoringJobMounts(in kdmpapi.DataExportObjectReference, expectedMou
 		return "", false, nil
 	}
 	if _, err := task.DoRetryWithTimeout(checkTask, defaultTimeout, progressCheckInterval); err != nil {
-		errMsg := fmt.Sprintf("max retries done, failed to check the PVC status in dataexport %v/%v: %v", in.Namespace, in.Name, checkErr)
+		errMsg := fmt.Sprintf("max retries done, failed in checking the PVC status of %v/%v: %v", in.Namespace, in.Name, checkErr)
 		logrus.Errorf("%v", errMsg)
 		// Exhausted all retries, fail the CR
 		return nil, fmt.Errorf("%v", errMsg)


### PR DESCRIPTION
**What this PR does / why we need it**:
pb-2075: Corrected the error handling in checking the PVC bound status.

**Which issue(s) this PR fixes** (optional)
Closes # pb-2075

Testing:
Tested with the invalid SC and made the PVC to be in pending state.
Backup failed after ~15 to 19 mints.
![Screenshot 2021-11-23 at 1 11 59 PM](https://user-images.githubusercontent.com/52188641/142989095-737c565c-9dc6-4d49-9cd2-d3cdc1a96e1c.png)
![Screenshot 2021-11-23 at 1 11 51 PM](https://user-images.githubusercontent.com/52188641/142989100-ec155bc5-dcfb-41d0-b08b-fdb0c97ada69.png)


