### PR TITLE
PB-2076: Additional check if node exists in the JobStatus call.

### DIFF
--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -203,6 +203,12 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		jobStatus = job.Status.Conditions[0].Type
 
 	}
+	err = utils.JobNodeExists(job)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to fetch the node info tied to the job %s/%s: %v", namespace, name, err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
 	jobErr, nodeErr := utils.IsJobOrNodeFailed(job)
 	var errMsg string
 	if jobErr {

--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -130,6 +130,12 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
+	err = utils.JobNodeExists(job)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to fetch the node info tied to the job %s/%s: %v", namespace, name, err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
 	var jobStatus batchv1.JobConditionType
 	if len(job.Status.Conditions) != 0 {
 		jobStatus = job.Status.Conditions[0].Type

--- a/pkg/drivers/kopiamaintenance/kopiamaintenance.go
+++ b/pkg/drivers/kopiamaintenance/kopiamaintenance.go
@@ -103,6 +103,12 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
+	err = utils.JobNodeExists(job)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to fetch the node info tied to the job %s/%s: %v", namespace, name, err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
 	var jobStatus batchv1.JobConditionType
 	if len(job.Status.Conditions) != 0 {
 		jobStatus = job.Status.Conditions[0].Type

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -112,6 +112,12 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = utils.JobNodeExists(job)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to fetch the node info tied to the job %s/%s: %v", namespace, name, err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
 	var jobStatus batchv1.JobConditionType
 	if len(job.Status.Conditions) != 0 {
 		jobStatus = job.Status.Conditions[0].Type

--- a/pkg/drivers/resticbackup/resticbackup.go
+++ b/pkg/drivers/resticbackup/resticbackup.go
@@ -99,6 +99,11 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = utils.JobNodeExists(job)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to fetch the node info tied to the job %s/%s: %v", namespace, name, err)
+		return nil, fmt.Errorf(errMsg)
+	}
 	var jobStatus batchv1.JobConditionType
 	if len(job.Status.Conditions) != 0 {
 		jobStatus = job.Status.Conditions[0].Type

--- a/pkg/drivers/resticrestore/resticrestore.go
+++ b/pkg/drivers/resticrestore/resticrestore.go
@@ -110,6 +110,11 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = utils.JobNodeExists(job)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to fetch the node info tied to the job %s/%s: %v", namespace, name, err)
+		return nil, fmt.Errorf(errMsg)
+	}
 	var jobStatus batchv1.JobConditionType
 	if len(job.Status.Conditions) != 0 {
 		jobStatus = job.Status.Conditions[0].Type

--- a/pkg/drivers/rsync/rsync.go
+++ b/pkg/drivers/rsync/rsync.go
@@ -77,6 +77,11 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = utils.JobNodeExists(job)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to fetch the node info tied to the job %s/%s: %v", namespace, name, err)
+		return nil, fmt.Errorf(errMsg)
+	}
 	var jobStatus batchv1.JobConditionType
 	if len(job.Status.Conditions) != 0 {
 		jobStatus = job.Status.Conditions[0].Type


### PR DESCRIPTION
signed-off-by: Diptiranjan

**What this PR does / why we need it**:
If the job is running and the node on which the job pod is scheduled gets shut down,
the pod keeps on getting spawned and the corresponding operation (like backup) will be in that stage forever.

With this PR, there is one more additional check in JobStatus has been introduced to check if the node exists or not.

**Which issue(s) this PR fixes** (optional)
Closes # Pb-2076

**Special notes for your reviewer**:
Test:
1. The already running job moved to the Failed state (backup - pb-21-system-test-57-ela-2f78453-interval-2021-11-22-131324)
2. Took a new successful backup (backup - pb-21-system-test-57-ela-2f78453-interval-2021-11-23-073026)
3. Again while backup was going on, poweroff one more node (backup - pb-21-system-test-57-ela-2f78453-interval-2021-11-23-081506 and pb-21-system-test-57-ela-2f78453-interval-2021-11-23-081506)



<img width="1788" alt="Screenshot 2021-11-23 at 2 05 21 PM" src="https://user-images.githubusercontent.com/51692470/142992405-a3874d9e-1c81-4c98-be20-3d2e93646408.png">


