### PR TITLE
pb-2101 Added hostaccess scc in the backup job for ocp platform.

### DIFF
--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -445,6 +445,12 @@ func roleFor() *rbacv1.Role {
 				Resources: []string{"volumebackups"},
 				Verbs:     []string{rbacv1.VerbAll},
 			},
+			{
+				APIGroups:     []string{"security.openshift.io"},
+				Resources:     []string{"securitycontextconstraints"},
+				ResourceNames: []string{"hostaccess"},
+				Verbs:         []string{"use"},
+			},
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
pb-2101 Added hostaccess scc in the backup job for ocp platform.

**Which issue(s) this PR fixes** (optional)
Closes # pb-2101.

**Special notes for your reviewer**:
Since the SCC issue is blocking the 2.8.1 release, i have hardcoded the SCC for now. Will make it CM configurable.

