### PR TITLE
[PB-2084]: Reading dataexport CR with schedops api instead of contoller client call.

### DIFF
--- a/pkg/controllers/dataexport/dataexport.go
+++ b/pkg/controllers/dataexport/dataexport.go
@@ -11,6 +11,7 @@ import (
 	"github.com/portworx/kdmp/pkg/utils"
 	"github.com/portworx/kdmp/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
+	"github.com/portworx/sched-ops/k8s/kdmp"
 	"github.com/sirupsen/logrus"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -73,8 +74,7 @@ func (c *Controller) Init(mgr manager.Manager) error {
 func (c *Controller) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	logrus.Tracef("Reconciling DataExport %s/%s", request.Namespace, request.Name)
 
-	dataExport := &kdmpapi.DataExport{}
-	err := c.client.Get(context.TODO(), request.NamespacedName, dataExport)
+	dataExport, err := kdmp.Instance().GetDataExport(request.Name, request.Namespace)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.


### PR DESCRIPTION
signed-off-by: Diptiranjan

**What this PR does / why we need it**:
Even after updating dataexport CR, for some of the fields we used to get stale entries.
Hence the change to move to sched ops api.

**Which issue(s) this PR fixes** (optional)
Closes # PB-2084

**Special notes for your reviewer**:
Test : Updated in PB-2084

