### PR TITLE
PB-2136 Fetching resource requirements from config map

### DIFF
--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -398,7 +398,7 @@ func addJobLabels(labels map[string]string) map[string]string {
 
 func buildJob(jobName string, jobOptions drivers.JobOpts) (*batchv1.Job, error) {
 	fn := "buildJob"
-	resources, err := utils.KopiaResourceRequirements()
+	resources, err := utils.KopiaResourceRequirements(jobOptions.JobConfigMap, jobOptions.JobConfigMapNs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -306,7 +306,7 @@ func addJobLabels(labels map[string]string, jobOpts drivers.JobOpts) map[string]
 }
 
 func buildJob(jobName string, jobOpts drivers.JobOpts) (*batchv1.Job, error) {
-	resources, err := utils.KopiaResourceRequirements()
+	resources, err := utils.KopiaResourceRequirements(jobOpts.JobConfigMap, jobOpts.JobConfigMapNs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drivers/kopiamaintenance/kopiamaintenance.go
+++ b/pkg/drivers/kopiamaintenance/kopiamaintenance.go
@@ -292,7 +292,7 @@ func addJobLabels(labels map[string]string) map[string]string {
 }
 
 func buildJob(jobName string, jobOpts drivers.JobOpts) (*batchv1beta1.CronJob, error) {
-	resources, err := utils.KopiaResourceRequirements()
+	resources, err := utils.KopiaResourceRequirements(jobOpts.JobConfigMap, jobOpts.JobConfigMapNs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -166,7 +166,7 @@ func jobFor(
 ) (*batchv1.Job, error) {
 	labels := addJobLabels(jobOption.Labels)
 
-	resources, err := utils.KopiaResourceRequirements()
+	resources, err := utils.KopiaResourceRequirements(jobOption.JobConfigMap, jobOption.JobConfigMapNs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drivers/utils/utils.go
+++ b/pkg/drivers/utils/utils.go
@@ -269,23 +269,27 @@ func ToImagePullSecret(name string) []corev1.LocalObjectReference {
 }
 
 // KopiaResourceRequirements returns ResourceRequirements for the kopiaexecutor container.
-func KopiaResourceRequirements() (corev1.ResourceRequirements, error) {
-	requestCPU := drivers.DefaultKopiaExecutorRequestCPU
-	if customRequestCPU := os.Getenv(drivers.KopiaExecutorRequestCPU); customRequestCPU != "" {
-		requestCPU = customRequestCPU
+func KopiaResourceRequirements(configMap, ns string) (corev1.ResourceRequirements, error) {
+	requestCPU := strings.TrimSpace(GetConfigValue(configMap, ns, drivers.KopiaExecutorRequestCPU))
+	if requestCPU == "" {
+		requestCPU = drivers.DefaultKopiaExecutorRequestCPU
 	}
-	requestMem := drivers.DefaultKopiaExecutorRequestMemory
-	if customRequestMemory := os.Getenv(drivers.KopiaExecutorRequestMemory); customRequestMemory != "" {
-		requestMem = customRequestMemory
+
+	requestMem := strings.TrimSpace(GetConfigValue(configMap, ns, drivers.KopiaExecutorRequestMemory))
+	if requestMem == "" {
+		requestMem = drivers.DefaultKopiaExecutorRequestMemory
 	}
-	limitCPU := drivers.DefaultKopiaExecutorLimitCPU
-	if customLimitCPU := os.Getenv(drivers.KopiaExecutorLimitCPU); customLimitCPU != "" {
-		limitCPU = customLimitCPU
+
+	limitCPU := strings.TrimSpace(GetConfigValue(configMap, ns, drivers.KopiaExecutorLimitCPU))
+	if limitCPU == "" {
+		limitCPU = drivers.DefaultKopiaExecutorLimitCPU
 	}
-	limitMem := drivers.DefaultKopiaExecutorLimitMemory
-	if customLimitMemory := os.Getenv(drivers.KopiaExecutorLimitMemory); customLimitMemory != "" {
-		limitMem = customLimitMemory
+
+	limitMem := strings.TrimSpace(GetConfigValue(configMap, ns, drivers.KopiaExecutorLimitMemory))
+	if limitMem == "" {
+		limitMem = drivers.DefaultKopiaExecutorLimitMemory
 	}
+
 	return toResourceRequirements(requestCPU, requestMem, limitCPU, limitMem)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
```
PB-2136 Fetching resource requirements from config map
    - Resources like CPU limit, memory limit to be read from config map
```

**Which issue(s) this PR fixes** (optional)
PB-2136

**Special notes for your reviewer**:

Manual test

Config map data 
```
[root@prashanth-winter-fighter-2 aws-eks]# kd describe cm kdmp-config -nkube-system
Name:         kdmp-config
Namespace:    kube-system
Labels:       <none>
Annotations:  <none>

Data
====
KDMP_KOPIAEXECUTOR_IMAGE:
----
portworx/kopiaexecutor:master
KDMP_KOPIAEXECUTOR_LIMIT_CPU:
----
0.3
KDMP_KOPIAEXECUTOR_LIMIT_MEMORY:
----
1Gi
KDMP_KOPIAEXECUTOR_REQUEST_CPU:
----
0.2
KDMP_KOPIAEXECUTOR_REQUEST_MEMORY:
----
700Mi
KDMP_BACKUP_JOB_LIMIT:
----
5
KDMP_DELETE_JOB_LIMIT:
----
5
KDMP_KOPIAEXECUTOR_IMAGE_SECRET:
----

KDMP_MAINTENANCE_JOB_LIMIT:
----
5
KDMP_RESTORE_JOB_LIMIT:
----
5
Events:  <none>
[root@prashanth-winter-fighter-2 aws-eks]#
[ prashanth-winter-fighter-2 ][  0$ root@prashanth-winte  1-$ root@

```


Below is jobspec which reflects values picked from the config map
```

[root@prashanth-winter-fighter-2 aws-eks]# kd describe job backup-4d4bed0-1469866-efs -nefs
Name:           backup-4d4bed0-1469866-efs
Namespace:      efs
Selector:       controller-uid=5deb586b-5bf7-4aea-959c-718848e4ab02
Labels:         kdmp.portworx.com/applicationbackup-cr-name=pk3-4c5e52d
                kdmp.portworx.com/applicationbackup-cr-uid=4d4bed0
                kdmp.portworx.com/backupobject-name=pk3
                kdmp.portworx.com/backupobject-uid=4c5e52d6-d372-45f6-ab4b-a2861bc94634
                kdmp.portworx.com/driver-name=kopiabackup
                kdmp.portworx.com/pvc-name=mysql-efs-claim
                kdmp.portworx.com/pvc-uid=1469866
Annotations:    stork.libopenstorage.org/skip-resource: true
Parallelism:    1
Completions:    1
Start Time:     Thu, 16 Dec 2021 13:42:14 +0000
Pods Statuses:  1 Running / 0 Succeeded / 0 Failed
Pod Template:

     /kopiaexecutor backup --volume-backup-name backup-4d4bed0-1469866-efs --credentials backup-4d4bed0-1469866-efs --backup-location pk-aws-bl-4c5e52d --backup-location-namespace efs --backup-namespace efs --repository efs-mysql-efs-claim --source-path-glob /data/*/pvc-1469866b-b027-4bd2-8c52-a69b92f18985/mount
    Limits:
      cpu:     300m
      memory:  1Gi
    Requests:
      cpu:        200m
      memory:     700Mi
    Environment:  <none>
    Mounts:
      /data from vol (rw)
      /etc/cred-secret from cred-secret (ro)
  Volumes:
   vol:
    Type:          HostPath (bare host directory volume)
    Path:          /var/lib/kubelet/pods/76926dbf-91de-4eee-8303-702fff22ea62/volumes
    HostPathType:
   cred-secret:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  backup-4d4bed0-1469866-efs
    Optional:    false
Events:
  Type    Reason            Age    From            Message
  ----    ------            ----   ----            -------
  Normal  SuccessfulCreate  3m39s  job-controller  Created pod: backup-4d4bed0-1469866-efs-dljxk
```
