### PR TITLE
pb-2131: Fixed couple of error handling issues.

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -467,7 +467,7 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 		cleanupTask := func() (interface{}, bool, error) {
 			cleanupErr := c.cleanUp(driver, dataExport)
 			if cleanupErr != nil {
-				errMsg := fmt.Sprintf("failed to remove resources: %s", err)
+				errMsg := fmt.Sprintf("failed to remove resources: %s", cleanupErr)
 				logrus.Errorf("%v", errMsg)
 				return "", true, fmt.Errorf("%v", errMsg)
 			}
@@ -922,7 +922,7 @@ func (c *Controller) stageLocalSnapshotRestore(ctx context.Context, dataExport *
 		data := updateDataExportDetail{
 			stage:  kdmpapi.DataExportStageTransferScheduled,
 			status: kdmpapi.DataExportStatusInitial,
-			reason: "going to do generic restore as restoring from local snapshot did not happen",
+			reason: "switching to restore from objectstore bucket as restoring from local snapshot did not happen",
 		}
 		return false, c.updateStatus(dataExport, data)
 	}
@@ -1146,19 +1146,24 @@ func (c *Controller) cleanUp(driver drivers.Interface, de *kdmpapi.DataExport) e
 func (c *Controller) cleanupLocalRestoredSnapshotResources(de *kdmpapi.DataExport, ignorePVC bool) error {
 
 	var cleanupErr error
+	var snapshotDriverName string
+	var snapshotDriver snapshotter.Driver
+	var vb *kdmpapi.VolumeBackup
+	var bl *storkapi.BackupLocation
 	t := func() (interface{}, bool, error) {
 
-		snapshotDriverName, cleanupErr := c.getSnapshotDriverName(de)
-		if cleanupErr != nil {
-			return nil, false, fmt.Errorf("failed to get snapshot driver name: %v", cleanupErr)
+		snapshotDriverName, cleanupErr = c.getSnapshotDriverName(de)
+		if snapshotDriverName == "" {
+			logrus.Errorf("cleanupLocalRestoredSnapshotResources: snapshotDriverName is empty: %v", cleanupErr)
+			return nil, false, nil
 		}
 
-		snapshotDriver, cleanupErr := c.snapshotter.Driver(snapshotDriverName)
+		snapshotDriver, cleanupErr = c.snapshotter.Driver(snapshotDriverName)
 		if cleanupErr != nil {
 			return nil, false, fmt.Errorf("failed to get snapshot driver for %v: %v", snapshotDriverName, cleanupErr)
 		}
 
-		vb, cleanupErr := kdmpopts.Instance().GetVolumeBackup(context.Background(),
+		vb, cleanupErr = kdmpopts.Instance().GetVolumeBackup(context.Background(),
 			de.Spec.Source.Name, de.Spec.Source.Namespace)
 		if cleanupErr != nil {
 			msg := fmt.Sprintf("Error accessing volumebackup %s in namespace %s : %v",
@@ -1167,7 +1172,7 @@ func (c *Controller) cleanupLocalRestoredSnapshotResources(de *kdmpapi.DataExpor
 			return nil, false, fmt.Errorf(msg)
 		}
 
-		bl, cleanupErr := stork.Instance().GetBackupLocation(vb.Spec.BackupLocation.Name, vb.Spec.BackupLocation.Namespace)
+		bl, cleanupErr = stork.Instance().GetBackupLocation(vb.Spec.BackupLocation.Name, vb.Spec.BackupLocation.Namespace)
 		if cleanupErr != nil {
 			msg := fmt.Sprintf("Error while getting backuplocation %s/%s : %v",
 				de.Spec.Source.Namespace, de.Spec.Source.Name, cleanupErr)


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-2131: Fixed couple of error handling issues.

        - if snapshotDriveName returned by getSnapshotDriverName is empty, ignore it in cleanupLocalRestoredSnapshotResources
          function and move on to kdmp restore stage.
        - In other instance, if snapshotDriveName returned by
          getSnapshotDriverName is empty, consider it as error.
        - The final error cleanupErr return as part of
          cleanupLocalRestoredSnapshotResources function is overwritten
          and getting nil error, in the case of error. Fixed it.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-2131

**Special notes for your reviewer**:
Testing:
Tested restore on the setup that did not has the volumesnapshot class. It defaulted to S3 object restore.
Note:
1) Currently the reason is getting updated to restore of volume successful. The reason "switching to restore from objectstore bucket as restoring from local snapshot did not happen" is getting updated after success. Will discuss on the option.
