### PR TITLE
Fix getDriverType() function

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -1642,6 +1642,11 @@ func hasLocalRestoreStage(de *kdmpapi.DataExport) bool {
 }
 
 func getDriverType(de *kdmpapi.DataExport) (string, error) {
+	// Quick return for rsync driver
+	if de.Spec.Type == kdmpapi.DataExportRsync {
+		return string(de.Spec.Type), nil
+	}
+	// Do some extra checks for generic backups/restores
 	src := de.Spec.Source
 	dst := de.Spec.Destination
 	doBackup := false
@@ -1663,7 +1668,6 @@ func getDriverType(de *kdmpapi.DataExport) (string, error) {
 	}
 
 	switch de.Spec.Type {
-	case kdmpapi.DataExportRsync:
 	case kdmpapi.DataExportRestic:
 		if doBackup {
 			return drivers.ResticBackup, nil


### PR DESCRIPTION

**What this PR does / why we need it**:
- We don't need to check for the src and dest fields if the driver type
  is rsync.



**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

