### PR TITLE
pb-2149: Removed the requeue logic from the kdmp controller reconcile

### DIFF
--- a/pkg/controllers/dataexport/dataexport.go
+++ b/pkg/controllers/dataexport/dataexport.go
@@ -25,6 +25,7 @@ import (
 
 var (
 	resyncPeriod                      = 10 * time.Second
+	requeuePeriod                     = 5 * time.Second
 	validateCRDInterval time.Duration = 10 * time.Second
 	validateCRDTimeout  time.Duration = 2 * time.Minute
 
@@ -83,7 +84,7 @@ func (c *Controller) Reconcile(ctx context.Context, request reconcile.Request) (
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		return reconcile.Result{RequeueAfter: 2 * time.Second}, err
+		return reconcile.Result{RequeueAfter: requeuePeriod}, nil
 	}
 
 	if !controllers.ContainsFinalizer(dataExport, cleanupFinalizer) {
@@ -94,10 +95,10 @@ func (c *Controller) Reconcile(ctx context.Context, request reconcile.Request) (
 	requeue, err := c.sync(context.TODO(), dataExport)
 	if err != nil {
 		logrus.Errorf("kdmp controller: %s/%s: %s", request.Namespace, request.Name, err)
-		return reconcile.Result{RequeueAfter: 2 * time.Second}, err
+		return reconcile.Result{RequeueAfter: requeuePeriod}, nil
 	}
 	if requeue {
-		return reconcile.Result{Requeue: requeue}, nil
+		return reconcile.Result{RequeueAfter: requeuePeriod}, nil
 	}
 
 	return reconcile.Result{RequeueAfter: resyncPeriod}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
```
    pb-2149: Removed the requeue logic from the kdmp controller reconcile

        - Removed the requeue logic and now will depend on the update
          events and the resynctime intervals for syncing up.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-2149

**Special notes for your reviewer**:
**Testing:**
Tested with backupschedule:

![Screenshot 2022-01-03 at 12 10 44 PM](https://user-images.githubusercontent.com/52188641/147904892-3c154366-515f-4ccf-94e9-89a3cd2eee16.png)



