### PR TITLE
[PB-2148]: Doing cleanup of vs and vsc crs only as part of dataexport cleanup.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-version v1.2.1
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7
-	github.com/libopenstorage/stork v1.4.1-0.20211113171730-e02f28e240e9
+	github.com/libopenstorage/stork v1.4.1-0.20220110185220-679ab515bf60
 	github.com/portworx/pxc v0.33.0
 	github.com/portworx/sched-ops v1.20.4-rc1.0.20211116074603-2b6905763b23
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -809,6 +809,8 @@ github.com/libopenstorage/stork v1.4.1-0.20211103064004-088d8fdeaa37 h1:gj6HUP3I
 github.com/libopenstorage/stork v1.4.1-0.20211103064004-088d8fdeaa37/go.mod h1:IEptmD89NFAueQB5YN+UXN32QLhFxkYSsU6xdTdkBRM=
 github.com/libopenstorage/stork v1.4.1-0.20211113171730-e02f28e240e9 h1:vTkz9X9uepzpUC5wxCaRkatDqOVBHrwXePDhqQgGGTI=
 github.com/libopenstorage/stork v1.4.1-0.20211113171730-e02f28e240e9/go.mod h1:NTt7xK9DqWpXLEBJI4WEz/XTUG3EkW0zcqyOMO5Xp2w=
+github.com/libopenstorage/stork v1.4.1-0.20220110185220-679ab515bf60 h1:t9UczICVXpyf+MmWBrwb/PxmOqFFNwcSeTO6mRtoDMI=
+github.com/libopenstorage/stork v1.4.1-0.20220110185220-679ab515bf60/go.mod h1:b3DcJzBjQANQMWoSNhdEl6eLuSOsDysqvSO0fGAcKbQ=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
@@ -1016,6 +1018,7 @@ github.com/portworx/kdmp v0.4.1-0.20211008122639-3554850ec03c/go.mod h1:a1NbL4OP
 github.com/portworx/kdmp v0.4.1-0.20211020042040-649a87216a48/go.mod h1:ethpTE5btKfTpuuC0T3bQHTBCLymlUaBAa2pRoCJixM=
 github.com/portworx/kdmp v0.4.1-0.20211103043446-cc5455f203d0/go.mod h1:BZ9ApnLFaMdxC4jd1inOw4ICfUI8AzyicAo+wL9ZSZY=
 github.com/portworx/kdmp v0.4.1-0.20211108115338-ba2bebf06ffb/go.mod h1:cbaFBCLFTtF0taXtGR2zGD89k0gl7fNl+n4Vi9p4gmI=
+github.com/portworx/kdmp v0.4.1-0.20220110105647-9b545fe9fad8/go.mod h1:RAXbeaO/JmwQPRJCDdOoY/UsmGPY/awWsL4FbDOqAVk=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20191223203141-f42097b1fcd8/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200311180812-b2c72382d652/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=

--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -117,11 +117,6 @@ func (d Driver) DeleteJob(id string) error {
 		return fmt.Errorf(errMsg)
 	}
 
-	if err := coreops.Instance().DeleteSecret(name, namespace); err != nil && !apierrors.IsNotFound(err) {
-		errMsg := fmt.Sprintf("deletion of backup credential secret %s failed: %v", name, err)
-		logrus.Errorf("%s: %v", fn, errMsg)
-		return fmt.Errorf(errMsg)
-	}
 	if err := utils.CleanServiceAccount(name, namespace); err != nil {
 		errMsg := fmt.Sprintf("deletion of service account %s/%s failed: %v", namespace, name, err)
 		logrus.Errorf("%s: %v", fn, errMsg)

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -12,7 +12,6 @@ import (
 	"github.com/portworx/kdmp/pkg/jobratelimit"
 	kdmpops "github.com/portworx/kdmp/pkg/util/ops"
 	"github.com/portworx/sched-ops/k8s/batch"
-	coreops "github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -82,10 +81,6 @@ func (d Driver) StartJob(opts ...drivers.JobOption) (id string, err error) {
 func (d Driver) DeleteJob(id string) error {
 	namespace, name, err := utils.ParseJobID(id)
 	if err != nil {
-		return err
-	}
-
-	if err := coreops.Instance().DeleteSecret(name, namespace); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 

--- a/pkg/drivers/resticbackup/resticbackup.go
+++ b/pkg/drivers/resticbackup/resticbackup.go
@@ -73,10 +73,6 @@ func (d Driver) DeleteJob(id string) error {
 		return err
 	}
 
-	if err := coreops.Instance().DeleteSecret(name, namespace); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
 	if err := utils.CleanServiceAccount(name, namespace); err != nil {
 		return err
 	}

--- a/pkg/drivers/resticrestore/resticrestore.go
+++ b/pkg/drivers/resticrestore/resticrestore.go
@@ -84,10 +84,6 @@ func (d Driver) DeleteJob(id string) error {
 		return err
 	}
 
-	if err := coreops.Instance().DeleteSecret(name, namespace); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
 	if err := utils.CleanServiceAccount(name, namespace); err != nil {
 		return err
 	}

--- a/vendor/github.com/libopenstorage/stork/pkg/snapshotter/snapshotter.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/snapshotter/snapshotter.go
@@ -90,7 +90,7 @@ type Driver interface {
 	// Restore from local snapshot if present
 	RestoreFromLocalSnapshot(backupLocation *storkapi.BackupLocation, pvc *v1.PersistentVolumeClaim, snapshotDriverName, pvcUID, backupUID, objectPath, namespace string) (bool, error)
 	// Cleanup resources if restore from localsnapshot fails
-	CleanUpRestoredResources(backupLocation *storkapi.BackupLocation, pvc *v1.PersistentVolumeClaim, pvcUID, backupUID, objectPath, namespace string) error
+	CleanUpRestoredResources(backupLocation *storkapi.BackupLocation, pvcUID, backupUID, objectPath, namespace string) error
 }
 
 // Snapshotter inteface returns a Driver object

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -188,7 +188,7 @@ github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1
 github.com/kubernetes-incubator/external-storage/snapshot/pkg/client
 # github.com/libopenstorage/openstorage-sdk-clients v0.109.0
 github.com/libopenstorage/openstorage-sdk-clients/sdk/golang
-# github.com/libopenstorage/stork v1.4.1-0.20211113171730-e02f28e240e9
+# github.com/libopenstorage/stork v1.4.1-0.20220110185220-679ab515bf60
 ## explicit
 github.com/libopenstorage/stork/pkg/apis/stork
 github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1


### PR DESCRIPTION
signed-off-by: Diptiranjan

**What this PR does / why we need it**:
Cleaning up vs and vsc crs in the final delete of dataexport.

**Which issue(s) this PR fixes** (optional)
Closes # PB-2148

**Special notes for your reviewer**:

Test:
Covered following scenarios

1. Generic Backup and restore of csi volumes with snapshotting with volumebinding mode as WaitForFirstConsumer.
2.  Generic Backup and restore of csi volumes with snapshotting with volumebinding mode as immediate.
3. Native backup and restore of gke volumes with snapshotting with volumebinding mode as WaitForFirstConsumer.

