### PR TITLE
pb-2219: Added logic to take care of the custom registry for kopia executor image.

### DIFF
--- a/pkg/apis/kdmp/v1alpha1/dataexport.go
+++ b/pkg/apis/kdmp/v1alpha1/dataexport.go
@@ -95,11 +95,15 @@ type DataExport struct {
 
 // DataExportSpec defines configuration parameters for DataExport.
 type DataExportSpec struct {
-	Type                 DataExportType            `json:"type,omitempty"`
-	ClusterPair          string                    `json:"clusterPair,omitempty"`
-	SnapshotStorageClass string                    `json:"snapshotStorageClass,omitempty"`
-	Source               DataExportObjectReference `json:"source,omitempty"`
-	Destination          DataExportObjectReference `json:"destination,omitempty"`
+	Type                 DataExportType `json:"type,omitempty"`
+	ClusterPair          string         `json:"clusterPair,omitempty"`
+	SnapshotStorageClass string         `json:"snapshotStorageClass,omitempty"`
+	// TriggeredFrom is to know which module is created the dataexport CR.
+	// The use-case is to know from where to get the kopia executor image
+	TriggeredFrom   string                    `json:"triggerFrom,omitempty"`
+	TriggeredFromNs string                    `json:"triggerFromNs,omitempty"`
+	Source          DataExportObjectReference `json:"source,omitempty"`
+	Destination     DataExportObjectReference `json:"destination,omitempty"`
 }
 
 // DataExportObjectReference contains enough information to let you inspect the referred object.

--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -1526,6 +1526,8 @@ func startTransferJob(
 		)
 	case drivers.KopiaBackup:
 		return drv.StartJob(
+			drivers.WithKopiaImageExecutorSource(dataExport.Spec.TriggeredFrom),
+			drivers.WithKopiaImageExecutorSourceNs(dataExport.Spec.TriggeredFromNs),
 			drivers.WithSourcePVC(srcPVCName),
 			drivers.WithRepoPVC(getRepoPVCName(dataExport, srcPVCName)),
 			drivers.WithNamespace(dataExport.Spec.Source.Namespace),
@@ -1542,6 +1544,8 @@ func startTransferJob(
 		)
 	case drivers.KopiaRestore:
 		return drv.StartJob(
+			drivers.WithKopiaImageExecutorSource(dataExport.Spec.TriggeredFrom),
+			drivers.WithKopiaImageExecutorSourceNs(dataExport.Spec.TriggeredFromNs),
 			drivers.WithDestinationPVC(dataExport.Spec.Destination.Name),
 			drivers.WithNamespace(dataExport.Spec.Destination.Namespace),
 			drivers.WithVolumeBackupName(dataExport.Spec.Source.Name),

--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -274,6 +274,20 @@ func jobFor(
 		splitCmd = append(splitCmd, "--compression", jobOption.Compression)
 		cmd = strings.Join(splitCmd, " ")
 	}
+	imageRegistry, imageRegistrySecret, err := utils.GetKopiaExecutorImageRegistryAndSecret(
+		jobOption.KopiaImageExecutorSource,
+		jobOption.KopiaImageExecutorSourceNs,
+	)
+	if err != nil {
+		logrus.Errorf("jobFor: getting kopia image registry and image secret failed during backup: %v", err)
+		return nil, err
+	}
+	var kopiaExecutorImage string
+	if len(imageRegistry) != 0 {
+		kopiaExecutorImage = fmt.Sprintf("%s/%s", imageRegistry, utils.GetKopiaExecutorImageName())
+	} else {
+		kopiaExecutorImage = utils.GetKopiaExecutorImageName()
+	}
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -292,12 +306,12 @@ func jobFor(
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ImagePullSecrets:   utils.ToImagePullSecret(utils.KopiaExecutorImageSecret(jobOption.JobConfigMap, jobOption.JobConfigMapNs)),
+					ImagePullSecrets:   utils.ToImagePullSecret(imageRegistrySecret),
 					ServiceAccountName: jobName,
 					Containers: []corev1.Container{
 						{
 							Name:            "kopiaexecutor",
-							Image:           utils.KopiaExecutorImage(jobOption.JobConfigMap, jobOption.JobConfigMapNs),
+							Image:           kopiaExecutorImage,
 							ImagePullPolicy: corev1.PullAlways,
 							Command: []string{
 								"/bin/sh",

--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -184,6 +184,21 @@ func jobFor(
 		jobOption.VolumeBackupDeleteNamespace,
 	}, " ")
 
+	imageRegistry, imageRegistrySecret, err := utils.GetKopiaExecutorImageRegistryAndSecret(
+		jobOption.KopiaImageExecutorSource,
+		jobOption.KopiaImageExecutorSourceNs,
+	)
+	if err != nil {
+		logrus.Errorf("jobFor: getting kopia image registry and image secret failed during delete: %v", err)
+		return nil, err
+	}
+	var kopiaExecutorImage string
+	if len(imageRegistry) != 0 {
+		kopiaExecutorImage = fmt.Sprintf("%s/%s", imageRegistry, utils.GetKopiaExecutorImageName())
+	} else {
+		kopiaExecutorImage = utils.GetKopiaExecutorImageName()
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -202,11 +217,11 @@ func jobFor(
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					ServiceAccountName: jobOption.ServiceAccountName,
-					ImagePullSecrets:   utils.ToImagePullSecret(utils.KopiaExecutorImageSecret(jobOption.JobConfigMap, jobOption.JobConfigMapNs)),
+					ImagePullSecrets:   utils.ToImagePullSecret(imageRegistrySecret),
 					Containers: []corev1.Container{
 						{
 							Name:  "kopiaexecutor",
-							Image: utils.KopiaExecutorImage(jobOption.JobConfigMap, jobOption.JobConfigMapNs),
+							Image: kopiaExecutorImage,
 							// TODO: Need to revert it to NotPresent. For now keep it as PullAlways.
 							ImagePullPolicy: corev1.PullAlways,
 							Command: []string{

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -191,6 +191,21 @@ func jobFor(
 		vb.Status.SnapshotID,
 	}, " ")
 
+	imageRegistry, imageRegistrySecret, err := utils.GetKopiaExecutorImageRegistryAndSecret(
+		jobOption.KopiaImageExecutorSource,
+		jobOption.KopiaImageExecutorSourceNs,
+	)
+	if err != nil {
+		logrus.Errorf("jobFor: getting kopia image registry and image secret failed during restore: %v", err)
+		return nil, err
+	}
+	var kopiaExecutorImage string
+	if len(imageRegistry) != 0 {
+		kopiaExecutorImage = fmt.Sprintf("%s/%s", imageRegistry, utils.GetKopiaExecutorImageName())
+	} else {
+		kopiaExecutorImage = utils.GetKopiaExecutorImageName()
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -208,12 +223,12 @@ func jobFor(
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ImagePullSecrets:   utils.ToImagePullSecret(utils.KopiaExecutorImageSecret(jobOption.JobConfigMap, jobOption.JobConfigMapNs)),
+					ImagePullSecrets:   utils.ToImagePullSecret(imageRegistrySecret),
 					ServiceAccountName: jobName,
 					Containers: []corev1.Container{
 						{
 							Name:            "kopiaexecutor",
-							Image:           utils.KopiaExecutorImage(jobOption.JobConfigMap, jobOption.JobConfigMapNs),
+							Image:           kopiaExecutorImage,
 							ImagePullPolicy: corev1.PullAlways,
 							Command: []string{
 								"/bin/sh",

--- a/pkg/drivers/options.go
+++ b/pkg/drivers/options.go
@@ -40,8 +40,32 @@ type JobOpts struct {
 	PodDataPath                 string
 	// JobConfigMap holds any config needs to be provided to job
 	// from the caller. Eg: executor image name, secret, etc..
-	JobConfigMap   string
-	JobConfigMapNs string
+	JobConfigMap               string
+	JobConfigMapNs             string
+	KopiaImageExecutorSource   string
+	KopiaImageExecutorSourceNs string
+}
+
+// WithKopiaImageExecutorSource is job parameter.
+func WithKopiaImageExecutorSource(source string) JobOption {
+	return func(opts *JobOpts) error {
+		if strings.TrimSpace(source) == "" {
+			return fmt.Errorf("kopia image executor source should be set")
+		}
+		opts.KopiaImageExecutorSource = strings.TrimSpace(source)
+		return nil
+	}
+}
+
+// WithKopiaImageExecutorSourceNs is job parameter.
+func WithKopiaImageExecutorSourceNs(namespace string) JobOption {
+	return func(opts *JobOpts) error {
+		if strings.TrimSpace(namespace) == "" {
+			return fmt.Errorf("kopia image executor source namespace should be set")
+		}
+		opts.KopiaImageExecutorSourceNs = strings.TrimSpace(namespace)
+		return nil
+	}
 }
 
 // WithBackupObjectName is job parameter.


### PR DESCRIPTION
**What this PR does / why we need it**:
```
    pb-2219: Added logic to take care of the custom registry for kopia executor image.

        - Added TriggeredFrom and TriggeredFromNs fiels in DE to know from which
          module the DE is triggered. Based on that, we will read the regitry name and
          image secret from corresponding deployment spec.
        - In the each driver, calling utils.GetKopiaExecutorImageRegistryAndSecret to get the
          registry name and image secret and use it in the job spec.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-2219

**Special notes for your reviewer**:

1. Testing by integrating with stork.
2. Will raise a separate stork PR.
