### PR TITLE
pb-2219: removed the check for empty image secret as it is valid

### DIFF
--- a/pkg/drivers/utils/utils.go
+++ b/pkg/drivers/utils/utils.go
@@ -249,7 +249,7 @@ func GetImageRegistryFromDeployment(name, namespace string) (string, string, err
 func GetKopiaExecutorImageRegistryAndSecret(source, sourceNs string) (string, string, error) {
 	var registry, registrySecret string
 	var err error
-	if len(os.Getenv(kopiaExecutorImageRegistryEnvVar)) == 0 || len(os.Getenv(kopiaExecutorImageRegistrySecretEnvVar)) == 0 {
+	if len(os.Getenv(kopiaExecutorImageRegistryEnvVar)) == 0 {
 		registry, registrySecret, err = GetImageRegistryFromDeployment(source, sourceNs)
 		if err != nil {
 			logrus.Errorf("GetKopiaExecutorImageRegistryAndSecret: error in getting image registory from %v:%v deployment", sourceNs, source)


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-2219: removed the check for empty image secret as it is valid
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-2219

**Special notes for your reviewer**:

