### PR TITLE
pb-2323: Fixed issue in the repo name for live generic backup.

### DIFF
--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -439,12 +439,14 @@ func buildJob(jobName string, jobOptions drivers.JobOpts) (*batchv1.Job, error) 
 			logrus.Errorf("%s: %v", fn, errMsg)
 			return nil, fmt.Errorf(errMsg)
 		}
+		pvcNamespace := jobOptions.Namespace
 		jobOptions.Namespace = resourceNamespace
 		return jobForLiveBackup(
 			jobOptions,
 			jobName,
 			pods[0],
 			resources,
+			pvcNamespace,
 		)
 	}
 

--- a/pkg/drivers/kopiabackup/kopiabackuplive.go
+++ b/pkg/drivers/kopiabackup/kopiabackuplive.go
@@ -22,6 +22,7 @@ func jobForLiveBackup(
 	jobName string,
 	mountPod corev1.Pod,
 	resources corev1.ResourceRequirements,
+	pvcNamespace string,
 ) (*batchv1.Job, error) {
 	volDir, err := getVolumeDirectory(jobOption.SourcePVCName, jobOption.SourcePVCNamespace)
 	if err != nil {
@@ -56,7 +57,7 @@ func jobForLiveBackup(
 		"--backup-namespace",
 		jobOption.Namespace,
 		"--repository",
-		toRepoName(jobOption.RepoPVCName, jobOption.Namespace),
+		toRepoName(jobOption.RepoPVCName, pvcNamespace),
 		"--source-path-glob",
 		backupPath,
 	}, " ")


### PR DESCRIPTION
**What this PR does / why we need it**:
```
    pb-2323: Fixed issue in the repo name for live generic backup.

        - For generic live backup, we will create job and job pods in
          the kube-system namespace but repo name, we will still
          maintain it as <pvc-ns>-<pvc-name.
        - So that restore will able to use the repo name as <pvc-ns>-<pvc-name
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-2323

**Special notes for your reviewer**:
Tested with a live backup restore of mysql app.
![Screenshot 2022-04-20 at 1 04 55 PM](https://user-images.githubusercontent.com/52188641/164175378-c89c67e9-fbd3-433b-8cc3-bafd91c66116.png)

