### PR TITLE
[PB-2322]: Quick maintenance to use proper username and cleanup older configs before connecting to another repo.

### DIFF
--- a/pkg/kopia/command.go
+++ b/pkg/kopia/command.go
@@ -11,7 +11,7 @@ const (
 	baseCmd    = "kopia"
 	logDir     = "/tmp"
 	cacheDir   = "/tmp"
-	configFile = "/tmp/kopiconfig"
+	configFile = "/tmp/kopiaconfig"
 )
 
 // Command defines the essential fields required to

--- a/pkg/kopia/maintenanceset.go
+++ b/pkg/kopia/maintenanceset.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 
 	cmdexec "github.com/portworx/kdmp/pkg/executor"
 	"github.com/sirupsen/logrus"
@@ -31,7 +32,15 @@ func GetMaintenanceSetCommand() (*Command, error) {
 		logrus.Infof("%v", errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
-	owner := rootUser + hostname
+	curUser := rootUser
+	// Use the current user for maintenance as container may not run with root user always
+	user, err := user.Current()
+	if err != nil {
+		logrus.Errorf("failed to get current user: %v", err)
+	} else {
+		curUser = fmt.Sprintf("%s@", user.Username)
+	}
+	owner := curUser + hostname
 	logrus.Debugf("GetMaintenanceSetCommand: owner %v", owner)
 	return &Command{
 		Name:             "maintenance",


### PR DESCRIPTION
Signed-off-by: Diptiranjan

**What this PR does / why we need it**:
Fixes Quick maintenance jobs if container does not run with root user.
Also fixes if more that one repo is there in the bucket.

**Which issue(s) this PR fixes** (optional)
Closes # PB-2322

**Special notes for your reviewer**:
*Test*
1. Tested the quick maintenance job run in OCP  cluster . Results have been updated in PB-2322.

