### PR TITLE
[pb-2326]-(Security) Modify base image to rhel ubi8 minimal from ubuntu

### DIFF
--- a/Dockerfile.kopia
+++ b/Dockerfile.kopia
@@ -1,23 +1,16 @@
-FROM ubuntu
+FROM registry.access.redhat.com/ubi8-minimal:latest
 
 MAINTAINER Portworx Inc. <support@portworx.com>
 
-RUN apt-get update && apt-get install bash curl vim make git wget gpg -y
-RUN curl -s https://kopia.io/signing-key | apt-key add -
+RUN microdnf install bash curl vim make git wget gpg ca-certificates yum && \
+        microdnf update && \
+        microdnf clean all
 
-RUN echo "deb http://packages.kopia.io/apt/ stable main" |  tee /etc/apt/sources.list.d/kopia.list
-RUN apt-get update \
-    && apt-get dist-upgrade -y \
-    && apt-get install -y --no-install-recommends \
-        ca-certificates \
-    && apt-get clean -y \
-    && apt-get autoremove -y \
-    && rm -rf /tmp/* /var/tmp/* \
-    && rm -rf /var/lib/apt/lists/*
+RUN rpm --import https://kopia.io/signing-key
 
-RUN apt update
+COPY kopia.repo /etc/yum.repos.d/kopia.repo
 
-RUN apt install kopia=0.9.4
+RUN yum install -y kopia-0.9.4
 WORKDIR /
 
 COPY ./bin/kopiaexecutor /

--- a/kopia.repo
+++ b/kopia.repo
@@ -1,0 +1,6 @@
+[Kopia]
+name=Kopia
+baseurl=http://packages.kopia.io/rpm/stable/$basearch/
+gpgcheck=1
+enabled=1
+gpgkey=https://kopia.io/signing-key


### PR DESCRIPTION
Signed-off-by: Kesavan Thiruvenkadasamy <kthiruvenkadasamy@purestorage.com>

**What this PR does / why we need it**:
The base image is modified from ubuntu to RHEL ubi8-minimal to mitigate security vulnerabilities

**Which issue(s) this PR fixes** (optional)
Closes #PB-2326



Tested on efs volume (backup and restore) in eks cluster (fixed image : portworx/kopiaexecutor:1.2.0-v2)

<img width="1566" alt="Screenshot 2022-04-21 at 7 16 14 PM" src="https://user-images.githubusercontent.com/101168875/164473034-53580f90-1e5a-41ca-90da-9f0c0ea44be3.png">

<img width="1442" alt="Screenshot 2022-04-21 at 7 17 51 PM" src="https://user-images.githubusercontent.com/101168875/164473142-47db65a3-4413-4c52-b4d7-4f96e843863b.png">

<img width="400" alt="Screenshot 2022-04-21 at 7 18 14 PM" src="https://user-images.githubusercontent.com/101168875/164473175-5bab09a2-c111-4833-b553-b22fe1d72221.png">

