### PR TITLE
pb-2330: Made fix to support image name to have custom repo as well.

### DIFF
--- a/Dockerfile.unittest
+++ b/Dockerfile.unittest
@@ -2,7 +2,7 @@ FROM ubuntu
 
 MAINTAINER Portworx Inc. <support@portworx.com>
 
-RUN apt-get update && apt-get install bash curl vim make git wget gpg -y
+RUN apt-get update && apt-get install bash curl vim make git wget gpg bzip2 -y
 RUN apt-get install gcc -y
 
 RUN curl https://dl.google.com/go/go1.16.6.linux-amd64.tar.gz -o go1.16.6.linux-amd64.tar.gz

--- a/pkg/drivers/utils/utils.go
+++ b/pkg/drivers/utils/utils.go
@@ -235,10 +235,9 @@ func GetImageRegistryFromDeployment(name, namespace string) (string, string, err
 	}
 	imageFields := strings.Split(deploy.Spec.Template.Spec.Containers[0].Image, "/")
 	// Here the assumption is that the image format will be <registry-name>/<extra-dir-name>/<repo-name>/image:tag
-	// or <repo-name>/image:tag. If repo name contains any path (<registry-name>/<repo-name>/<extra-dir-name>/image:tag), below logic will not work.
+	// or <repo-name>/image:tag or <registry-name>/<repo-name>/<extra-dir-name>/image:tag).
 	// Customer might have extra dirs before the repo-name as mentioned above
-	// here minus 2 is for image name and repo name exclusion
-	registryFields := imageFields[0 : len(imageFields)-2]
+	registryFields := imageFields[0 : len(imageFields)-1]
 	registry := strings.Join(registryFields, "/")
 	imageSecret := deploy.Spec.Template.Spec.ImagePullSecrets
 	if imageSecret != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
```
 pb-2330: Made fix to support image name to have custom repo as well.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-2330

**Special notes for your reviewer**:
```
Now we will all the below image format:
 <custom-registry-name>/<extra-dir-name>/<custom-repo-name>/image:tag
 <custom-registry-name>/<custom-repo-name>/<extra-dir-name>/image:tag
 <repo-name>/image:tag -- default registry of docker.io will be taken.
 ```