### PR TITLE
pb-2330: remove the portworx repo name from default KopiaExecutorImage to support custom repo

### DIFF
--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -19,7 +19,7 @@ const (
 // Docker images.
 const (
 	ResticExecutorImage = "portworx/resticexecutor"
-	KopiaExecutorImage  = "portworx/kopiaexecutor"
+	KopiaExecutorImage  = "kopiaexecutor"
 	RsyncImage          = "eeacms/rsync"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-2330: remove the portworx repo name from default KopiaExecutorImage to support custom repo
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-2330

**Special notes for your reviewer**:

