### PR TITLE
pb-2328: Support both v1 & v1beta1 version of the volumeSnapshot

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	k8sMinVersionCronJobV1 = "1.21"
+	k8sMinVersionCronJobV1        = "1.21"
+	k8sMinVersionVolumeSnapshotV1 = "1.20"
 )
 
 // Base version information.
@@ -48,6 +49,23 @@ func Get() Info {
 		Compiler:   runtime.Compiler,
 		Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
+}
+
+// RequiresV1VolumeSnapshot returns true if V1 version of VolumeSnapshot APIs need to be called
+func RequiresV1VolumeSnapshot() (bool, error) {
+	clusterK8sVersion, _, err := GetFullVersion()
+	if err != nil {
+		return false, err
+	}
+	requiredK8sVer, err := version.NewVersion(k8sMinVersionVolumeSnapshotV1)
+	if err != nil {
+		return false, err
+
+	}
+	if clusterK8sVersion.GreaterThanOrEqual(requiredK8sVer) {
+		return true, nil
+	}
+	return false, nil
 }
 
 // RequiresV1Registration returns true if crd nees to be registered as apiVersion V1


### PR DESCRIPTION
- Added support for VolumeSnapshot V1 Apis which is GA since kubernetes
  1.20 version.
- The v1beta1 is still kept for supporting older K8s versions

Signed-off-by: Lalatendu Das <ldas@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: The volumesnapshot API v1beta1 support is removed from k8s version 1.20, hence we need to add v1 APIs along with v1beta1. 

**Which issue(s) this PR fixes** (optional)
Closes # pb-2328

**Special notes for your reviewer**:

