### PR TITLE
[PB-2428] - Security: Remove unused git package to mitigate security vulnerability

### DIFF
--- a/Dockerfile.kopia
+++ b/Dockerfile.kopia
@@ -2,8 +2,7 @@ FROM registry.access.redhat.com/ubi8-minimal:latest
 
 MAINTAINER Portworx Inc. <support@portworx.com>
 
-RUN microdnf install bash curl vim make git wget gpg ca-certificates yum && \
-        microdnf update && \
+RUN microdnf install bash curl vim make wget gpg ca-certificates yum && \
         microdnf clean all
 
 RUN rpm --import https://kopia.io/signing-key


### PR DESCRIPTION
Signed-off-by: Kesavan Thiruvenkadasamy <kthiruvenkadasamy@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Security fix

**Which issue(s) this PR fixes** (optional)
Closes #PB-2428

Tested by taking backup and restore on efs volumes (generic backup)

**Special notes for your reviewer**:
removed `microdnf update` as it was upgrading some packages to vulnerable versions

