### PR TITLE
pb-2820: Fixed the volumesnapshot version check

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,12 +1,18 @@
 package version
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"runtime"
 
 	version "github.com/hashicorp/go-version"
+	kSnapshotClient "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
 	coreops "github.com/portworx/sched-ops/k8s/core"
+	"github.com/sirupsen/logrus"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -53,19 +59,35 @@ func Get() Info {
 
 // RequiresV1VolumeSnapshot returns true if V1 version of VolumeSnapshot APIs need to be called
 func RequiresV1VolumeSnapshot() (bool, error) {
-	clusterK8sVersion, _, err := GetFullVersion()
+	config, err := rest.InClusterConfig()
 	if err != nil {
 		return false, err
 	}
-	requiredK8sVer, err := version.NewVersion(k8sMinVersionVolumeSnapshotV1)
+	cs, err := kSnapshotClient.NewForConfig(config)
 	if err != nil {
 		return false, err
-
 	}
-	if clusterK8sVersion.GreaterThanOrEqual(requiredK8sVer) {
-		return true, nil
+	_, err = cs.SnapshotV1().VolumeSnapshots("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil && !k8s_errors.IsNotFound(err) {
+		logrus.Errorf("Failed to get VolumeSnapshot v1 version error: %s", err)
+		return false, err
+	} else if k8s_errors.IsNotFound(err) {
+		// Try for v1beta1
+		_, err := cs.SnapshotV1beta1().VolumeSnapshots("").List(context.TODO(), metav1.ListOptions{})
+		if err != nil && !k8s_errors.IsNotFound(err) {
+			logrus.Errorf("Failed to get VolumeSnapshot v1beta1 version CRD error: %s", err)
+			return false, err
+		} else if k8s_errors.IsNotFound(err) {
+			logrus.Warnf("VolumeSnapshot CRDs are not installed in the cluster, Please install appropriate version of volumesnapshot CRDs: %s", err)
+			// Not attempting for v1alpha1 CRD search, it is too old to adopt
+			// Returning error as nil to keep the previous behavior unchanged, which doesn't bail out in the absence of CRDs
+			return false, nil
+		}
+		//Found v1beta1 CRD
+		return false, nil
 	}
-	return false, nil
+	//Found the v1 CRD
+	return true, nil
 }
 
 // RequiresV1Registration returns true if crd nees to be registered as apiVersion V1


### PR DESCRIPTION
The version of volumesnapshot API to be called is decided based on
whichever version of valid VS CRD installed in the system.
This is because for k8s 1.20 both v1 and v1beta can be installed.

Signed-off-by: Lalatendu Das <ldas@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: This enables the volumesnapshot version detection based on CRD installed instead of checking the k8s version.

**Which issue(s) this PR fixes** (optional)
Closes # pb-2820

**Special notes for your reviewer**:
Unit Test :
Checked by vendoring into stork the KDMP backups are taken gracefully with v1 & v1beta1 version.
Please look into pb-2820 for detailed screenshot for kdmp backup and delete test case operations. And restore operations too.
