### PR TITLE
Pb 3031 : preventing resource deletion in case of failure using a configMap flag

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -1190,6 +1190,13 @@ func (c *Controller) stageLocalSnapshotRestoreInProgress(ctx context.Context, da
 
 func (c *Controller) cleanUp(driver drivers.Interface, de *kdmpapi.DataExport) error {
 	var bl *storkapi.BackupLocation
+	doCleanup, err := utils.DoCleanupResource()
+	if err != nil {
+		return err
+	}
+	if (de.Status.Status == kdmpapi.DataExportStatusFailed) && !doCleanup {
+		return nil
+	}
 	if driver == nil {
 		return fmt.Errorf("driver is nil")
 	}

--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -429,6 +429,17 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 		data := updateDataExportDetail{
 			stage: kdmpapi.DataExportStageFinal,
 		}
+		// Append the job-pod log to stork's pod log in case of failure
+		// it is best effort approach, hence errors are ignored.
+		if dataExport.Status.Status == kdmpapi.DataExportStatusFailed {
+			if dataExport.Status.TransferID != "" {
+				namespace, name, err := utils.ParseJobID(dataExport.Status.TransferID)
+				if err != nil {
+					logrus.Infof("job-pod name and namespace extraction failed: %v", err)
+				}
+				appendPodLogToStork(name, namespace)
+			}
+		}
 		cleanupTask := func() (interface{}, bool, error) {
 			cleanupErr := c.cleanUp(driver, dataExport)
 			if cleanupErr != nil {
@@ -450,6 +461,34 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 		return false, nil
 	}
 	return false, nil
+}
+
+func appendPodLogToStork(jobName string, namespace string) {
+	// Get job and check whether it has live pod attaced to it
+	job, err := batch.Instance().GetJob(jobName, namespace)
+	if err != nil && !k8sErrors.IsNotFound(err) {
+		logrus.Infof("failed in getting job %v/%v with err: %v", namespace, jobName, err)
+	}
+	pods, err := core.Instance().GetPods(
+		job.Namespace,
+		map[string]string{
+			"job-name": job.Name,
+		},
+	)
+	if err != nil {
+		logrus.Infof("failed in fetching job pods %s/%s: %v", namespace, jobName, err)
+	}
+	for _, pod := range pods.Items {
+		numLogLines := int64(50)
+		podLog, err := core.Instance().GetPodLog(pod.Name, pod.Namespace, &corev1.PodLogOptions{TailLines: &numLogLines})
+		if err != nil {
+			logrus.Infof("error fetching log of job-pod %s: %v", pod.Name, err)
+		} else {
+			logrus.Infof("start of job-pod [%s]'s log...", pod.Name)
+			logrus.Infof(podLog)
+			logrus.Infof("end of job-pod [%s]'s log...", pod.Name)
+		}
+	}
 }
 
 func (c *Controller) createJobCredCertSecrets(


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: This PR introduces a config map which is when set to false the resources won'yt be cleaned up. By default resources are cleaned up upon success of failure of backup process. 
Additionally it captures the pod log and redirects that to stork pod log. 

**Which issue(s) this PR fixes** (optional) pb-3031, pb-3003
Closes # pb-3031, pb-3003

**Special notes for your reviewer**:
Kindly check and let me know  if the place where we are capturing the job-pod log and redirecting would be the apt place or not. Just wandering Will there be a case when capturing at this place will miss the log to be redirected to stork pod. 

** Unit Test **
Tested it by  vendoring this code to stork and taken back-up and simulated a backup failure.
Using the **_backupdiagctl_**  tool captured the resources from remote cluster and pasted the tree cmd o/p. below is the snapshot of the same

1. **_pb3031_** is the namespace where in application was running, this is a kdmp backup. captured files in it. 
![image](https://user-images.githubusercontent.com/15273500/186214636-f2dd277f-1d8d-4a5f-baaa-b67935a0eeaa.png)
2. Below is kube-system namespace has remaining resource which got prevented to be deleted.

![image](https://user-images.githubusercontent.com/15273500/186215083-022c579a-6843-423e-909b-fa3274ed0aa7.png)

![image](https://user-images.githubusercontent.com/15273500/186215228-a28d1144-b336-4692-9b80-ac48c1a9b9b6.png)

![image](https://user-images.githubusercontent.com/15273500/186215413-3d5841e0-6a0e-4c93-92a2-151281ee0d6c.png)

