### PR TITLE
PB-2956: Enable volume backup for NFS backed backuplocation

### DIFF
--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"fmt"
+
 	batchv1 "k8s.io/api/batch/v1"
 )
 
@@ -46,6 +47,7 @@ const (
 	CertFileName         = "public.crt"
 	CertSecretName       = "tls-s3-cert"
 	CertMount            = "/etc/tls-s3-cert"
+	NfsMount             = "/tmp/nfs-target/"
 )
 
 // Driver job options.

--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -362,7 +362,27 @@ func jobFor(
 			},
 		},
 	}
+	if len(jobOption.NfsServer) != 0 {
+		volumeMount := corev1.VolumeMount{
+			Name:      utils.NfsVolumeName,
+			MountPath: drivers.NfsMount,
+		}
+		job.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+			job.Spec.Template.Spec.Containers[0].VolumeMounts,
+			volumeMount,
+		)
+		volume := corev1.Volume{
+			Name: utils.NfsVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				NFS: &corev1.NFSVolumeSource{
+					Server: jobOption.NfsServer,
+					Path:   jobOption.NfsExportDir,
+				},
+			},
+		}
 
+		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, volume)
+	}
 	if drivers.CertFilePath != "" {
 		volumeMount := corev1.VolumeMount{
 			Name:      utils.TLSCertMountVol,

--- a/pkg/drivers/kopiabackup/kopiabackuplive.go
+++ b/pkg/drivers/kopiabackup/kopiabackuplive.go
@@ -163,6 +163,28 @@ func jobForLiveBackup(
 		},
 	}
 
+	if len(jobOption.NfsServer) != 0 {
+		volumeMount := corev1.VolumeMount{
+			Name:      utils.NfsVolumeName,
+			MountPath: drivers.NfsMount,
+		}
+		job.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+			job.Spec.Template.Spec.Containers[0].VolumeMounts,
+			volumeMount,
+		)
+		volume := corev1.Volume{
+			Name: utils.NfsVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				NFS: &corev1.NFSVolumeSource{
+					Server: jobOption.NfsServer,
+					Path:   jobOption.NfsExportDir,
+				},
+			},
+		}
+
+		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, volume)
+	}
+
 	if drivers.CertFilePath != "" {
 		volumeMount := corev1.VolumeMount{
 			Name:      utils.TLSCertMountVol,

--- a/pkg/drivers/options.go
+++ b/pkg/drivers/options.go
@@ -45,6 +45,24 @@ type JobOpts struct {
 	KopiaImageExecutorSource   string
 	KopiaImageExecutorSourceNs string
 	NodeAffinity               map[string]string
+	NfsServer                  string
+	NfsExportDir               string
+}
+
+// WithNfsServer is job parameter.
+func WithNfsServer(server string) JobOption {
+	return func(opts *JobOpts) error {
+		opts.NfsServer = strings.TrimSpace(server)
+		return nil
+	}
+}
+
+// WithNfsExportDir is job parameter.
+func WithNfsExportDir(exportDir string) JobOption {
+	return func(opts *JobOpts) error {
+		opts.NfsExportDir = strings.TrimSpace(exportDir)
+		return nil
+	}
 }
 
 // WithKopiaImageExecutorSource is job parameter.

--- a/pkg/drivers/utils/common.go
+++ b/pkg/drivers/utils/common.go
@@ -26,7 +26,9 @@ const (
 	// BackupObjectUIDKey - label key to store backup object uid
 	BackupObjectUIDKey = "backup-object-uid"
 	// TLSCertMountVol mount vol name for tls certificate secret
-	TLSCertMountVol       = "tls-secret"
+	TLSCertMountVol = "tls-secret"
+	// NfsVolumeName is the Volume spec's name to be used in kopia Job Spec
+	NfsVolumeName         = "nfs-target"
 	defaultTimeout        = 1 * time.Minute
 	progressCheckInterval = 5 * time.Second
 	// KdmpConfigmapName kdmp config map name

--- a/pkg/executor/kopia/kopiabackup.go
+++ b/pkg/executor/kopia/kopiabackup.go
@@ -3,10 +3,12 @@ package kopia
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"time"
 
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/objectstore"
+	"github.com/portworx/kdmp/pkg/drivers"
 	"github.com/portworx/kdmp/pkg/executor"
 	"github.com/portworx/kdmp/pkg/kopia"
 	"github.com/portworx/sched-ops/task"
@@ -35,10 +37,11 @@ var (
 )
 
 var (
-	kopiaProvderType = map[storkv1.BackupLocationType]string{
+	kopiaProviderType = map[storkv1.BackupLocationType]string{
 		storkv1.BackupLocationS3:     "s3",
 		storkv1.BackupLocationGoogle: "gcs",
 		storkv1.BackupLocationAzure:  "azure",
+		storkv1.BackupLocationNFS:    "filesystem",
 	}
 )
 
@@ -106,11 +109,24 @@ func runBackup(sourcePath string) error {
 	// kopia doesn't have a way to know if repository is already initialized.
 	// Repository create needs to run only first time.
 	// Check if kopia.repository exists
-	exists, err := isRepositoryExists(repo)
+	// TODO : We need to check for kopia.repository file. For now we are
+	// skipping the check and assuming the repo doesn't exist specifically for NFS.
+	// Read the BL type
+	fPath := drivers.KopiaCredSecretMount + "/" + "type"
+	blType, err := ioutil.ReadFile(fPath)
 	if err != nil {
-		errMsg := fmt.Sprintf("repository exists check for repo %s failed: %v", repo.Name, err)
-		logrus.Errorf("%s: %v", fn, errMsg)
-		return fmt.Errorf("%s: %v", errMsg, err)
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", fPath, err)
+		logrus.Errorf("%v", errMsg)
+		return fmt.Errorf(errMsg)
+	}
+	var exists = false
+	if storkv1.BackupLocationType(blType) != storkv1.BackupLocationNFS {
+		exists, err = isRepositoryExists(repo)
+		if err != nil {
+			errMsg := fmt.Sprintf("repository exists check for repo %s failed: %v", repo.Name, err)
+			logrus.Errorf("%s: %v", fn, errMsg)
+			return fmt.Errorf("%s: %v", errMsg, err)
+		}
 	}
 	if !exists {
 		if err = runKopiaCreateRepo(repo); err != nil {
@@ -198,7 +214,7 @@ func runKopiaCreateRepo(repository *executor.Repository) error {
 			repository.Path,
 			repository.Name,
 			repository.Password,
-			kopiaProvderType[repository.Type],
+			kopiaProviderType[repository.Type],
 			repository.S3Config.DisableSSL,
 		)
 	default:
@@ -206,13 +222,15 @@ func runKopiaCreateRepo(repository *executor.Repository) error {
 			repository.Path,
 			repository.Name,
 			repository.Password,
-			kopiaProvderType[repository.Type],
+			kopiaProviderType[repository.Type],
 			false,
 		)
 	}
 	if err != nil {
 		return err
 	}
+	// NFS doesn't need any special treatment for repo create command
+	// hence no case exist for it.
 	switch repository.Type {
 	case storkv1.BackupLocationS3:
 		repoCreateCmd = populateS3AccessDetails(repoCreateCmd, repository)
@@ -331,7 +349,7 @@ func runKopiaRepositoryConnect(repository *executor.Repository) error {
 			repository.Path,
 			repository.Name,
 			repository.Password,
-			kopiaProvderType[repository.Type],
+			kopiaProviderType[repository.Type],
 			repository.S3Config.DisableSSL,
 		)
 	default:
@@ -339,7 +357,7 @@ func runKopiaRepositoryConnect(repository *executor.Repository) error {
 			repository.Path,
 			repository.Name,
 			repository.Password,
-			kopiaProvderType[repository.Type],
+			kopiaProviderType[repository.Type],
 			false,
 		)
 	}

--- a/pkg/kopia/backup.go
+++ b/pkg/kopia/backup.go
@@ -81,12 +81,13 @@ func GetBackupCommand(path, repoName, password, provider, sourcePath string) (*C
 	}
 
 	return &Command{
-		Name:     "create",
-		Password: password,
-		Path:     path,
-		Dir:      sourcePath,
-		Provider: provider,
-		Args:     []string{"."},
+		Name:           "create",
+		Password:       password,
+		RepositoryName: repoName,
+		Path:           path,
+		Dir:            sourcePath,
+		Provider:       provider,
+		Args:           []string{"."},
 	}, nil
 }
 

--- a/pkg/kopia/command.go
+++ b/pkg/kopia/command.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 
 	cmdexec "github.com/portworx/kdmp/pkg/executor"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -35,7 +36,7 @@ type Command struct {
 	Env []string
 	// Password is the env for storing password
 	Password string
-	// Provider storage provider (aws, Google, Azure)
+	// Provider storage provider (aws, Google, Azure, filesystem)
 	Provider string
 	// SnapshotID snapshot ID
 	SnapshotID string
@@ -141,6 +142,22 @@ func (c *Command) CreateCmd() *exec.Cmd {
 			"--config-file",
 			configFile,
 		}
+	case "filesystem":
+		argsSlice = []string{
+			"repository",
+			c.Name, // create command
+			c.Provider,
+			"--path",
+			c.Path + c.RepositoryName,
+			"--password",
+			c.Password,
+			"--cache-directory",
+			cacheDir,
+			"--log-dir",
+			logDir,
+			"--config-file",
+			configFile,
+		}
 	}
 
 	argsSlice = append(argsSlice, c.Flags...)
@@ -175,6 +192,7 @@ func (c *Command) BackupCmd() *exec.Cmd {
 		cmd.Env = append(os.Environ(), c.Env...)
 	}
 	cmd.Dir = c.Dir
+	logrus.Infof("the backup command is %+v", cmd)
 	return cmd
 }
 
@@ -233,6 +251,22 @@ func (c *Command) ConnectCmd() *exec.Cmd {
 			c.Password,
 			"--prefix",
 			c.RepositoryName,
+			"--cache-directory",
+			cacheDir,
+			"--log-dir",
+			logDir,
+			"--config-file",
+			configFile,
+		}
+	case "filesystem":
+		argsSlice = []string{
+			"repository",
+			c.Name, // connect command
+			c.Provider,
+			"--path",
+			c.Path + c.RepositoryName,
+			"--password",
+			c.Password,
 			"--cache-directory",
 			cacheDir,
 			"--log-dir",


### PR DESCRIPTION
- kopia repo create and connect is added with filesystem option
- JOB spec enabled NFS volume mount specific metadata
- Use the PATH variable to represent NFS export directory
- Added NFS related switch cases as per need

Signed-off-by: Lalatendu Das <ldas@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

