### PR TITLE
PB-3093: Job framework for backup to invoke nfs executor

### DIFF
--- a/pkg/apis/kdmp/v1alpha1/resourceexport.go
+++ b/pkg/apis/kdmp/v1alpha1/resourceexport.go
@@ -45,6 +45,13 @@ const (
 	ResourceExportStatusSuccessful ResourceExportStatus = "Successful"
 )
 
+const (
+	// ResourceExportBackup backup op for resource upload
+	ResourceExportBackup ResourceExportType = "backup"
+	// ResourceExportRestore restore op for resource download
+	ResourceExportRestore ResourceExportType = "restore"
+)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/controllers/common.go
+++ b/pkg/controllers/common.go
@@ -1,7 +1,12 @@
 package controllers
 
 import (
+	"os"
 	"time"
+
+	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/portworx/sched-ops/k8s/stork"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 var (
@@ -15,4 +20,31 @@ var (
 	ValidateCRDTimeout time.Duration = 2 * time.Minute
 	// CleanupFinalizer cleanup finalizer
 	CleanupFinalizer = "kdmp.portworx.com/finalizer-cleanup"
+	// TaskDefaultTimeout timeout for retry task
+	TaskDefaultTimeout = 1 * time.Minute
+	// TaskProgressCheckInterval to check task progress at specified interval
+	TaskProgressCheckInterval = 5 * time.Second
 )
+
+// ReadBackupLocation fetching backuplocation CR
+func ReadBackupLocation(name, namespace, filePath string) (*storkapi.BackupLocation, error) {
+	if name != "" {
+		if namespace == "" {
+			namespace = "default"
+		}
+		return stork.Instance().GetBackupLocation(name, namespace)
+	}
+
+	// TODO: This is needed for restic, we can think of removing it later
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &storkapi.BackupLocation{}
+	if err = yaml.NewYAMLOrJSONDecoder(f, 1024).Decode(out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}

--- a/pkg/controllers/resourceexport/reconcile.go
+++ b/pkg/controllers/resourceexport/reconcile.go
@@ -1,1 +1,138 @@
 package resourceexport
+
+import (
+	"context"
+	"fmt"
+
+	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	kdmpapi "github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
+	kdmpcontroller "github.com/portworx/kdmp/pkg/controllers"
+	"github.com/portworx/kdmp/pkg/drivers"
+	"github.com/portworx/kdmp/pkg/drivers/driversinstance"
+	"github.com/portworx/kdmp/pkg/drivers/utils"
+	"github.com/portworx/sched-ops/task"
+	"github.com/sirupsen/logrus"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// updateResourceExportFields when and update needs to be done to ResourceExport
+// user can choose which filed to be updated and pass the same to updateStatus()
+type updateResourceExportFields struct {
+	status kdmpapi.ResourceExportStatus
+	// TODO: Enable for restore
+	//resources []*kdmpapi.ResourceInfo
+}
+
+func (c *Controller) process(ctx context.Context, in *kdmpapi.ResourceExport) (bool, error) {
+	if in == nil {
+		return false, nil
+	}
+	resourceExport := in.DeepCopy()
+
+	// Set to initial status to start with
+	if resourceExport.Status == "" {
+		updateData := updateResourceExportFields{
+			status: kdmpapi.ResourceExportStatusInitial,
+		}
+		return true, c.updateStatus(resourceExport, updateData)
+	}
+	// Get the driver type
+	opType := getOpType(resourceExport)
+	driver, err := driversinstance.Get(opType)
+	if err != nil {
+		updateData := updateResourceExportFields{
+			status: kdmpapi.ResourceExportStatusFailed,
+		}
+		return false, c.updateStatus(resourceExport, updateData)
+	}
+	blName := resourceExport.Spec.Destination.Name
+	blNamespace := resourceExport.Spec.Destination.Namespace
+	backupLocation, err := kdmpcontroller.ReadBackupLocation(blName, blNamespace, "")
+
+	if err != nil {
+		msg := fmt.Sprintf("reading of backuplocation [%v/%v] failed: %v", blNamespace, blName, err)
+		logrus.Errorf(msg)
+		updateData := updateResourceExportFields{
+			status: kdmpapi.ResourceExportStatusFailed,
+		}
+		return false, c.updateStatus(resourceExport, updateData)
+	}
+	var serr error
+	switch resourceExport.Status {
+	case kdmpapi.ResourceExportStatusInitial:
+		// start data transfer
+		_, serr = startNfsResourceJob(
+			driver,
+			utils.KdmpConfigmapName,
+			utils.KdmpConfigmapNamespace,
+			resourceExport,
+			backupLocation,
+		)
+		if serr != nil {
+			logrus.Errorf("line 73 err: %v", serr)
+		}
+	}
+
+	return true, nil
+}
+
+func (c *Controller) updateStatus(re *kdmpapi.ResourceExport, data updateResourceExportFields) error {
+	var updErr error
+	t := func() (interface{}, bool, error) {
+		namespacedName := types.NamespacedName{}
+		namespacedName.Name = re.Name
+		namespacedName.Namespace = re.Namespace
+		err := c.client.Get(context.TODO(), namespacedName, re)
+		if err != nil && !k8sErrors.IsNotFound(err) {
+			errMsg := fmt.Sprintf("failed in getting DE CR %v/%v: %v", re.Namespace, re.Name, err)
+			logrus.Infof("%v", errMsg)
+			return "", true, fmt.Errorf("%v", errMsg)
+		}
+		// TODO: In the restore path iterate over ResourceInfo{} list and only update the
+		// resource whose status as changed
+		if data.status != "" {
+			re.Status = data.status
+		}
+
+		updErr = c.client.Update(context.TODO(), re)
+		if updErr != nil {
+			errMsg := fmt.Sprintf("failed updating resourceExport CR %s: %v", re.Name, updErr)
+			logrus.Errorf("%v", errMsg)
+			return "", true, fmt.Errorf("%v", errMsg)
+		}
+		return "", false, nil
+	}
+	if _, err := task.DoRetryWithTimeout(t, kdmpcontroller.TaskDefaultTimeout, kdmpcontroller.TaskProgressCheckInterval); err != nil {
+		errMsg := fmt.Sprintf("max retries done, failed updating resourceExport CR %s: %v", re.Name, updErr)
+		logrus.Errorf("%v", errMsg)
+		// Exhausted all retries, fail the CR
+		return fmt.Errorf("%v", errMsg)
+	}
+
+	return nil
+
+}
+
+func getOpType(re *kdmpapi.ResourceExport) string {
+
+	return string(re.Type)
+}
+
+func startNfsResourceJob(
+	drv drivers.Interface,
+	jobConfigMap string,
+	jobConfigMapNs string,
+	re *kdmpapi.ResourceExport,
+	bl *storkapi.BackupLocation,
+) (string, error) {
+
+	switch drv.Name() {
+	case drivers.NFSBackup:
+		return drv.StartJob(
+			drivers.WithNfsServer(bl.Location.NfsConfig.NfsServerAddr),
+			drivers.WithNfsExportDir(bl.Location.Path),
+		)
+	}
+	return "", fmt.Errorf("unknown data transfer driver: %s", drv.Name())
+}

--- a/pkg/controllers/resourceexport/resourceexport.go
+++ b/pkg/controllers/resourceexport/resourceexport.go
@@ -77,7 +77,14 @@ func (c *Controller) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{Requeue: true}, c.client.Update(context.TODO(), restoreExport)
 	}
 
-	// TODO Need to add sync here
+	requeue, err := c.process(context.TODO(), restoreExport)
+	if err != nil {
+		logrus.Errorf("fail to execute sync function for restoreExport CR %v: %v", restoreExport.Name, err)
+		return reconcile.Result{RequeueAfter: kdmpcontroller.RequeuePeriod}, nil
+	}
+	if requeue {
+		return reconcile.Result{RequeueAfter: kdmpcontroller.RequeuePeriod}, nil
+	}
 
 	return reconcile.Result{RequeueAfter: kdmpcontroller.ResyncPeriod}, nil
 }

--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -15,6 +15,8 @@ const (
 	KopiaRestore     = "kopiarestore"
 	KopiaDelete      = "kopiadelete"
 	KopiaMaintenance = "kopiamaintenance"
+	NFSBackup        = "nfsbackup"
+	NFSRestore       = "nfsrestore"
 )
 
 // Docker images.

--- a/pkg/drivers/driversinstance/driversinstance.go
+++ b/pkg/drivers/driversinstance/driversinstance.go
@@ -9,6 +9,7 @@ import (
 	"github.com/portworx/kdmp/pkg/drivers/kopiadelete"
 	"github.com/portworx/kdmp/pkg/drivers/kopiamaintenance"
 	"github.com/portworx/kdmp/pkg/drivers/kopiarestore"
+	"github.com/portworx/kdmp/pkg/drivers/nfsbackup"
 	"github.com/portworx/kdmp/pkg/drivers/resticbackup"
 	"github.com/portworx/kdmp/pkg/drivers/resticrestore"
 	"github.com/portworx/kdmp/pkg/drivers/rsync"
@@ -24,6 +25,7 @@ var (
 		drivers.KopiaRestore:     kopiarestore.Driver{},
 		drivers.KopiaDelete:      kopiadelete.Driver{},
 		drivers.KopiaMaintenance: kopiamaintenance.Driver{},
+		drivers.NFSBackup:        nfsbackup.Driver{},
 	}
 )
 

--- a/pkg/drivers/nfsbackup/nfsbackup.go
+++ b/pkg/drivers/nfsbackup/nfsbackup.go
@@ -1,0 +1,218 @@
+package nfsbackup
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/portworx/kdmp/pkg/drivers"
+	"github.com/portworx/kdmp/pkg/drivers/utils"
+	"github.com/portworx/sched-ops/k8s/batch"
+
+	"github.com/sirupsen/logrus"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Driver is a nfsbackup implementation of the data export interface.
+type Driver struct{}
+
+// Name returns a name of the driver.
+func (d Driver) Name() string {
+	return drivers.NFSBackup
+}
+
+// StartJob creates a job for data transfer between volumes.
+func (d Driver) StartJob(opts ...drivers.JobOption) (id string, err error) {
+	// FOr every ns to be backed up a new job should be created
+	funct := "StartJob"
+	logrus.Infof("line 31 %s", funct)
+	o := drivers.JobOpts{}
+	for _, opt := range opts {
+		if opt != nil {
+			if err := opt(&o); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	job, err := buildJob(o)
+	if err != nil {
+		return "", err
+	}
+	if _, err = batch.Instance().CreateJob(job); err != nil && !apierrors.IsAlreadyExists(err) {
+		errMsg := fmt.Sprintf("creation of restore job %s failed: %v", o.RestoreExportName, err)
+		logrus.Errorf("%s: %v", funct, errMsg)
+		return "", fmt.Errorf(errMsg)
+	}
+
+	return "", nil
+}
+
+// DeleteJob stops data transfer between volumes.
+func (d Driver) DeleteJob(id string) error {
+
+	return nil
+}
+
+// JobStatus fetches job status
+func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
+
+	return nil, nil
+}
+
+func buildJob(
+	jobOptions drivers.JobOpts,
+) (*batchv1.Job, error) {
+	funct := "buildJob"
+	// Setup service account using same role permission as stork role
+	if err := utils.SetupNFSServiceAccount(jobOptions.RestoreExportName, jobOptions.Namespace, roleFor()); err != nil {
+		errMsg := fmt.Sprintf("error creating service account %s/%s: %v", jobOptions.Namespace, jobOptions.RestoreExportName, err)
+		logrus.Errorf("%s: %v", funct, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	resources, err := utils.KopiaResourceRequirements(jobOptions.JobConfigMap, jobOptions.JobConfigMapNs)
+	if err != nil {
+		return nil, err
+	}
+
+	job, err := jobForBackupResource(jobOptions, resources)
+	if err != nil {
+		errMsg := fmt.Sprintf("building restore job %s failed: %v", jobOptions.RestoreExportName, err)
+		logrus.Errorf("%s: %v", funct, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	if _, err = batch.Instance().CreateJob(job); err != nil && !apierrors.IsAlreadyExists(err) {
+		errMsg := fmt.Sprintf("creation of restore job %s failed: %v", jobOptions.RestoreExportName, err)
+		logrus.Errorf("%s: %v", funct, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	return job, nil
+
+}
+
+func roleFor() *rbacv1.ClusterRole {
+	role := &rbacv1.ClusterRole{
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"*"},
+				Resources: []string{"*"},
+				Verbs:     []string{rbacv1.VerbAll},
+			},
+		},
+	}
+
+	return role
+}
+
+func addJobLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	labels[drivers.DriverNameLabel] = drivers.NFSBackup
+	return labels
+}
+
+func jobForBackupResource(
+	jobOption drivers.JobOpts,
+	resources corev1.ResourceRequirements,
+) (*batchv1.Job, error) {
+	cmd := strings.Join([]string{
+		"/nfsexecutor",
+		"backup",
+		"--app-cr-name",
+		jobOption.AppCRName,
+		"--backup-namespace",
+		jobOption.AppCRNamespace,
+	}, " ")
+
+	labels := addJobLabels(jobOption.Labels)
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobOption.RestoreExportName,
+			Namespace: jobOption.Namespace,
+			Annotations: map[string]string{
+				utils.SkipResourceAnnotation: "true",
+			},
+			Labels: labels,
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &utils.JobPodBackOffLimit,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
+					ImagePullSecrets:   nil,
+					ServiceAccountName: jobOption.RestoreExportName,
+					//NodeName:           mountPod.Spec.NodeName,
+					Containers: []corev1.Container{
+						{
+							Name:            "nfsexecutor",
+							Image:           "pkumarn/nfsexecutor:latest",
+							ImagePullPolicy: corev1.PullAlways,
+							Command: []string{
+								"/bin/sh",
+								"-x",
+								"-c",
+								cmd,
+							},
+							Resources: resources,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "cred-secret",
+									MountPath: drivers.KopiaCredSecretMount,
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "cred-secret",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									//SecretName: utils.GetCredSecretName(jobOption.DataExportName),
+									// TODO: During integration change this to DE CR name as that is the
+									// secret created
+									SecretName: utils.GetCredSecretName(jobOption.RestoreExportName),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if len(jobOption.NfsServer) != 0 {
+		volumeMount := corev1.VolumeMount{
+			Name:      utils.NfsVolumeName,
+			MountPath: drivers.NfsMount,
+		}
+		job.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+			job.Spec.Template.Spec.Containers[0].VolumeMounts,
+			volumeMount,
+		)
+		volume := corev1.Volume{
+			Name: utils.NfsVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				NFS: &corev1.NFSVolumeSource{
+					Server: jobOption.NfsServer,
+					Path:   jobOption.NfsExportDir,
+				},
+			},
+		}
+
+		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, volume)
+	}
+
+	return job, nil
+}

--- a/pkg/drivers/options.go
+++ b/pkg/drivers/options.go
@@ -47,6 +47,17 @@ type JobOpts struct {
 	NodeAffinity               map[string]string
 	NfsServer                  string
 	NfsExportDir               string
+	RestoreExportName          string
+	AppCRName                  string
+	AppCRNamespace             string
+}
+
+// WithRestoreExport is job parameter
+func WithRestoreExport(name string) JobOption {
+	return func(opts *JobOpts) error {
+		opts.RestoreExportName = strings.TrimSpace(name)
+		return nil
+	}
 }
 
 // WithNfsServer is job parameter.

--- a/pkg/drivers/utils/common.go
+++ b/pkg/drivers/utils/common.go
@@ -110,6 +110,58 @@ func CleanServiceAccount(name, namespace string) error {
 	return nil
 }
 
+// SetupNFSServiceAccount create a service account and bind it to a provided role.
+func SetupNFSServiceAccount(name, namespace string, role *rbacv1.ClusterRole) error {
+	if role != nil {
+		role.Name, role.Namespace = name, namespace
+		role.Annotations = map[string]string{
+			SkipResourceAnnotation: "true",
+		}
+		if _, err := rbacops.Instance().CreateClusterRole(role); err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("create %s/%s cluster role: %s", namespace, name, err)
+		}
+		if _, err := rbacops.Instance().CreateClusterRoleBinding(clusterRoleBindingFor(name, namespace)); err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("create %s/%s cluster rolebinding: %s", namespace, name, err)
+		}
+	}
+	var sa *corev1.ServiceAccount
+	var err error
+	if sa, err = coreops.Instance().CreateServiceAccount(serviceAccountFor(name, namespace)); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("create %s/%s serviceaccount: %s", namespace, name, err)
+	}
+	t := func() (interface{}, bool, error) {
+		sa, err = coreops.Instance().GetServiceAccount(name, namespace)
+		if err != nil {
+			errMsg := fmt.Sprintf("failed fetching sa [%v/%v]: %v", name, namespace, err)
+			logrus.Tracef("%v", errMsg)
+			return "", true, fmt.Errorf("%v", errMsg)
+		}
+		if sa.Secrets == nil {
+			errMsg := fmt.Sprintf("secret token is missing in sa [%v/%v]", name, namespace)
+			return "", true, fmt.Errorf("%v", errMsg)
+		}
+		return "", false, nil
+	}
+	if _, err := task.DoRetryWithTimeout(t, defaultTimeout, progressCheckInterval); err != nil {
+		errMsg := fmt.Sprintf("max retries done, failed in fetching secret token of sa [%v/%v]: %v ", name, namespace, err)
+		logrus.Errorf("%v", errMsg)
+		// Exhausted all retries
+		return err
+	}
+
+	tokenName := sa.Secrets[0].Name
+	secretToken, err := coreops.Instance().GetSecret(tokenName, namespace)
+	if err != nil {
+		return fmt.Errorf("failed in getting secretToken [%v] of service account [%v/%v]: %v", tokenName, name, namespace, err)
+	}
+	secretToken.Annotations[SkipResourceAnnotation] = "true"
+	_, err = coreops.Instance().UpdateSecret(secretToken)
+	if err != nil {
+		return fmt.Errorf("failed in updating the secretToken [%v] of service account [%v/%v]: %v", tokenName, name, namespace, err)
+	}
+	return nil
+}
+
 func roleBindingFor(name, namespace string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -129,6 +181,29 @@ func roleBindingFor(name, namespace string) *rbacv1.RoleBinding {
 		RoleRef: rbacv1.RoleRef{
 			Name:     name,
 			Kind:     "Role",
+			APIGroup: rbacv1.GroupName,
+		},
+	}
+}
+
+func clusterRoleBindingFor(name, namespace string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				SkipResourceAnnotation: "true",
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      name,
+				Namespace: namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name:     name,
+			Kind:     "ClusterRole",
 			APIGroup: rbacv1.GroupName,
 		},
 	}

--- a/pkg/executor/nfs/nfsbkpresources.go
+++ b/pkg/executor/nfs/nfsbkpresources.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-openapi/inflect"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/resourcecollector"
+	"github.com/portworx/kdmp/pkg/drivers"
 	"github.com/portworx/kdmp/pkg/executor"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/core"
@@ -67,7 +68,7 @@ func uploadBkpResource(
 		logrus.Infof("%s:error fetching applicationbackup %s: %v", funct, applicationCRName, err)
 		return err
 	}
-	bkpDir := filepath.Join("/tmp", repo.Path, bkpNamespace, backup.ObjectMeta.Name, string(backup.ObjectMeta.UID))
+	bkpDir := filepath.Join(drivers.NfsMount, repo.Path, bkpNamespace, backup.ObjectMeta.Name, string(backup.ObjectMeta.UID))
 	if err := os.MkdirAll(bkpDir, 0777); err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
```
Job framework for backup to invoke nfs executor
Reconciler changes to act upon ResourceExport CR
```

**Which issue(s) this PR fixes** (optional)
pb-3093

**Special notes for your reviewer**:

