### PR TITLE
pb-3156: Updating the final success status in the backup CR in-memory for uploading it to metadata.json file

### DIFF
--- a/pkg/controllers/dataexport/dataexport.go
+++ b/pkg/controllers/dataexport/dataexport.go
@@ -62,7 +62,6 @@ func (c *Controller) Init(mgr manager.Manager) error {
 //
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
-//
 func (c *Controller) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	logrus.Tracef("Reconciling DataExport %s/%s", request.Namespace, request.Name)
 

--- a/pkg/drivers/utils/utils.go
+++ b/pkg/drivers/utils/utils.go
@@ -307,7 +307,7 @@ func GetImageRegistryFromDeployment(name, namespace string) (string, string, err
 	return registry, "", nil
 }
 
-//GetExecutorImageAndSecret returns the image name and secret to to use in the job pod
+// GetExecutorImageAndSecret returns the image name and secret to to use in the job pod
 func GetExecutorImageAndSecret(executorImageType, deploymentName, deploymentNs,
 	jobName string, jobOption drivers.JobOpts) (string, string, error) {
 	var imageRegistry, imageRegistrySecret string
@@ -422,7 +422,7 @@ func GetKopiaExecutorImageName() string {
 	return strings.Join([]string{drivers.KopiaExecutorImage, version.Get().GitVersion}, ":")
 }
 
-//GetNfsExecutorImageName - will return the default nfs executor image
+// GetNfsExecutorImageName - will return the default nfs executor image
 func GetNfsExecutorImageName() string {
 	return strings.Join([]string{drivers.NfsExecutorImage, version.Get().GitVersion}, ":")
 }
@@ -625,17 +625,17 @@ func CreateImageRegistrySecret(sourceName, destName, sourceNamespace, destNamesp
 	return nil
 }
 
-//GetCredSecretName - get credential secret name
+// GetCredSecretName - get credential secret name
 func GetCredSecretName(name string) string {
 	return CredSecret + "-" + name
 }
 
-//GetImageSecretName - get image secret name
+// GetImageSecretName - get image secret name
 func GetImageSecretName(name string) string {
 	return ImageSecret + "-" + name
 }
 
-//GetCertSecretName - get cert secret name
+// GetCertSecretName - get cert secret name
 func GetCertSecretName(name string) string {
 	return CertSecret + "-" + name
 }

--- a/pkg/executor/common.go
+++ b/pkg/executor/common.go
@@ -85,7 +85,7 @@ type GoogleConfig struct {
 	AccountKey string
 }
 
-//NfsConfig specifies the config required to connect to NFS Baqckuplocation
+// NfsConfig specifies the config required to connect to NFS Baqckuplocation
 type NfsConfig struct {
 	ServerAddr string
 }

--- a/pkg/restic/restore.go
+++ b/pkg/restic/restore.go
@@ -51,7 +51,8 @@ func GetRestoreCommand(
 // output of restic restore
 //
 // TODO: restic provides no progress info for a restore process now:
-//       https://github.com/restic/restic/issues/1154
+//
+//	https://github.com/restic/restic/issues/1154
 type RestoreProgressResponse struct {
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
```
    pb-3156: Updating the final success status in the backup CR in-memory
    copy for uploading it to metadata.json file
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3156

**Special notes for your reviewer**:
Tested and verified the content of the metadata.json file.
