### PR TITLE
pb-3146: For resource only backup maintenance job should pass

### DIFF
--- a/pkg/executor/kopia/maintenance.go
+++ b/pkg/executor/kopia/maintenance.go
@@ -136,7 +136,11 @@ func runMaintenance(maintenanceType string) error {
 		repoBaseDir := repo.Path + genericBackupDir + "/"
 		listOfSubDirs, err := returnDirList(repoBaseDir)
 		if err != nil {
-			logrus.Errorf("Failed to list sub directories in dir %v", repoBaseDir)
+			if os.IsNotExist(err) {
+				logrus.Warnf("No directory %v exists, verify if it is a resource only backup", repoBaseDir)
+				return nil
+			}
+			logrus.Errorf("Failed to list sub directories in dir %v : [%v]", repoBaseDir, err)
 			return err
 		}
 		var kopiaFile string


### PR DESCRIPTION
When there is a resource only backup the kopia maintenace job goes to crashloopbackoff state and keeps restarting. This is avoided by adding appropriate error check.

Signed-off-by: Lalatendu Das <ldas@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: For resource only backup the maintenance job crashloopbackoff contineously due to unavailability of generic-backup dir. Hence added appropriate error check to bail out gracefully.

**Which issue(s) this PR fixes** (optional)
Closes # pb-3146

**Special notes for your reviewer**:
Before fix :
![Pasted Graphic](https://user-images.githubusercontent.com/15273500/196497609-f2510e60-480c-4609-a5b7-ef1b93867338.png)

![Pasted Graphic 1](https://user-images.githubusercontent.com/15273500/196497651-878890ea-2b81-4831-ac41-a667351badf5.png)
After fix:
![image](https://user-images.githubusercontent.com/15273500/196497782-d6ad2ab3-647e-473e-8807-4ca6ca858deb.png)
