### PR TITLE
pb-3231: nfsconfig for an old backuplocation need to be nullified

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -293,6 +293,9 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 			return false, c.updateStatus(dataExport, data)
 		}
 
+		if backupLocation.Location.Type != storkapi.BackupLocationNFS {
+			backupLocation.Location.NfsConfig = &storkapi.NfsConfig{}
+		}
 		// start data transfer
 		id, err := startTransferJob(
 			driver,


### PR DESCRIPTION
For any older backuplocation which doesn't have any NFS config related setting that need to nullified before accessing its variables.

Signed-off-by: Lalatendu Das <ldas@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: For any existing backup location which is of non-nfs type there this nfs config would have been null hence we need to take proper measure to null initialise it before accessing its variables.

**Which issue(s) this PR fixes** (optional)
Closes # pb-3231

**Special notes for your reviewer**:
Verified in Kshthij's system it works fine.
