### PR TITLE
PB-3230 - Fix for not to fail if image registry secret is not found

### DIFF
--- a/pkg/drivers/utils/utils.go
+++ b/pkg/drivers/utils/utils.go
@@ -625,6 +625,10 @@ func CreateImageRegistrySecret(sourceName, destName, sourceNamespace, destNamesp
 	// and create one in the current job's namespace
 	secret, err := core.Instance().GetSecret(sourceName, sourceNamespace)
 	if err != nil {
+		// Safely exit if image registry secret is not found.
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		logrus.Errorf("failed in getting secret [%v/%v]: %v", sourceNamespace, sourceName, err)
 		return err
 	}
@@ -728,7 +732,7 @@ func CreateNfsPvc(pvcName string, pvName string, namespace string) error {
 		Spec: corev1.PersistentVolumeClaimSpec{
 			// Setting it to empty stringm so that default storage class will not selected.
 			StorageClassName: &empttyStorageClass,
-			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceName(corev1.ResourceStorage): resource.MustParse(nfsVolumeSize),


### PR DESCRIPTION
Signed-off-by: Kesavan Thiruvenkadasamy <kthiruvenkadasamy@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  Added fix for not to fail if there is no docker-registry secret (docregistry-secret)

**Which issue(s) this PR fixes** (optional)
Closes #[PB-3230](https://portworx.atlassian.net/browse/PB-3230)

**Special notes for your reviewer**:

Without fix 
![Screenshot 2022-11-09 at 12 59 17 PM](https://user-images.githubusercontent.com/101168875/200767590-68d687af-8602-4ae7-bf7d-2ed991d32cbd.png)
After fix 

![Screenshot 2022-11-09 at 1 04 09 PM](https://user-images.githubusercontent.com/101168875/200767642-848ffa67-d309-42b3-af65-e10b1e257dcd.png)


