### PR TITLE
pb-3245: fixed following issues in nfs resource backup and restore path

### DIFF
--- a/pkg/drivers/nfsbackup/nfsbackup.go
+++ b/pkg/drivers/nfsbackup/nfsbackup.go
@@ -191,7 +191,7 @@ func jobForBackupResource(
 	nfsExecutorImage, _, err := utils.GetExecutorImageAndSecret(drivers.NfsExecutorImage,
 		jobOption.NfsImageExecutorSource,
 		jobOption.NfsImageExecutorSourceNs,
-		jobOption.JobName,
+		jobOption.RestoreExportName,
 		jobOption)
 
 	if err != nil {

--- a/pkg/drivers/nfsrestore/nfsrestore.go
+++ b/pkg/drivers/nfsrestore/nfsrestore.go
@@ -211,7 +211,7 @@ func jobForRestoreResource(
 	nfsExecutorImage, _, err := utils.GetExecutorImageAndSecret(drivers.NfsExecutorImage,
 		jobOption.NfsImageExecutorSource,
 		jobOption.NfsImageExecutorSourceNs,
-		jobOption.JobName,
+		jobOption.RestoreExportName,
 		jobOption)
 	if err != nil {
 		logrus.Errorf("failed to get the executor image details")

--- a/pkg/drivers/utils/utils.go
+++ b/pkg/drivers/utils/utils.go
@@ -352,7 +352,13 @@ func GetExecutorImageAndSecret(executorImageType, deploymentName, deploymentNs,
 		}
 	}
 	if len(imageRegistrySecret) != 0 {
-		err = CreateImageRegistrySecret(imageRegistrySecret, jobName, jobOption.KopiaImageExecutorSourceNs, jobOption.Namespace)
+		var secretSourceNs string
+		if executorImageType == drivers.NfsExecutorImage {
+			secretSourceNs = jobOption.NfsImageExecutorSourceNs
+		} else {
+			secretSourceNs = jobOption.KopiaImageExecutorSourceNs
+		}
+		err = CreateImageRegistrySecret(imageRegistrySecret, jobName, secretSourceNs, jobOption.Namespace)
 		if err != nil {
 			return "", "", err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
```
  pb-3245: fixed following issues in nfs resource backup and restore path
        - jobName, which was used as secret name was not passed
          correctly to utils.GetExecutorImageAndSecret api.
        - Namespace to CreateImageRegistrySecret api need to passed
          based on the executor type.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3245

**Special notes for your reviewer**:
Tested on QA cluster.
