### PR TITLE
pb-3249: Added change to trim the label value, if it is greater than 63 chars

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -688,7 +688,7 @@ func (c *Controller) stageSnapshotScheduled(ctx context.Context, dataExport *kdm
 	snapName := toSnapName(dataExport.Spec.Source.Name, string(dataExport.UID))
 	annotations := make(map[string]string)
 	annotations[dataExportUIDAnnotation] = string(dataExport.UID)
-	annotations[dataExportNameAnnotation] = trimLabel(dataExport.Name)
+	annotations[dataExportNameAnnotation] = utils.GetValidLabel(dataExport.Name)
 	annotations[backupObjectUIDKey] = backupUID
 	annotations[pvcUIDKey] = pvcUID
 	labels := make(map[string]string)
@@ -1526,7 +1526,7 @@ func (c *Controller) restoreSnapshot(ctx context.Context, snapshotDriver snapsho
 	pvc.Annotations = make(map[string]string)
 	pvc.Annotations[skipResourceAnnotation] = "true"
 	pvc.Annotations[dataExportUIDAnnotation] = string(de.UID)
-	pvc.Annotations[dataExportNameAnnotation] = trimLabel(de.Name)
+	pvc.Annotations[dataExportNameAnnotation] = utils.GetValidLabel(de.Name)
 
 	// If storage class annotation is set , then put that annotation too in the temp pvc
 	// Sometimes the spec.storageclass might be empty, in that case the temp pvc may get the sc as the default sc
@@ -2077,13 +2077,6 @@ func toBoundJobPVCName(pvcName string, pvcUID string) string {
 	}
 	uidToken := strings.Split(pvcUID, "-")
 	return fmt.Sprintf("%s-%s-%s", "bound", truncatedPVCName, uidToken[0])
-}
-
-func trimLabel(label string) string {
-	if len(label) > 63 {
-		return label[:63]
-	}
-	return label
 }
 
 func getRepoPVCName(de *kdmpapi.DataExport, pvcName string) string {

--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -372,7 +372,7 @@ func toRepoName(pvcName, pvcNamespace string) string {
 
 func addVolumeBackupDeleteLabels(jobOpts drivers.JobOpts) map[string]string {
 	labels := make(map[string]string)
-	labels[utils.BackupObjectNameKey] = jobOpts.BackupObjectName
+	labels[utils.BackupObjectNameKey] = utils.GetValidLabel(jobOpts.BackupObjectName)
 	labels[utils.BackupObjectUIDKey] = jobOpts.BackupObjectUID
 	return labels
 }
@@ -383,7 +383,7 @@ func addJobLabels(labels map[string]string, jobOpts drivers.JobOpts) map[string]
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.KopiaDelete
-	labels[utils.BackupObjectNameKey] = jobOpts.BackupObjectName
+	labels[utils.BackupObjectNameKey] = utils.GetValidLabel(jobOpts.BackupObjectName)
 	labels[utils.BackupObjectUIDKey] = jobOpts.BackupObjectUID
 	return labels
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-3249: Added change to trim the label value, if it is greater than 63 chars
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3249

**Special notes for your reviewer**:
Tested deletion of backup object greater than 63 char.
