### PR TITLE
pb-3278 Added support for creating namespare if not present during vol restore

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -688,7 +688,7 @@ func (c *Controller) stageSnapshotScheduled(ctx context.Context, dataExport *kdm
 	snapName := toSnapName(dataExport.Spec.Source.Name, string(dataExport.UID))
 	annotations := make(map[string]string)
 	annotations[dataExportUIDAnnotation] = string(dataExport.UID)
-	annotations[dataExportNameAnnotation] = trimLabel(dataExport.Name)
+	annotations[dataExportNameAnnotation] = utils.GetValidLabel(dataExport.Name)
 	annotations[backupObjectUIDKey] = backupUID
 	annotations[pvcUIDKey] = pvcUID
 	labels := make(map[string]string)
@@ -1526,7 +1526,7 @@ func (c *Controller) restoreSnapshot(ctx context.Context, snapshotDriver snapsho
 	pvc.Annotations = make(map[string]string)
 	pvc.Annotations[skipResourceAnnotation] = "true"
 	pvc.Annotations[dataExportUIDAnnotation] = string(de.UID)
-	pvc.Annotations[dataExportNameAnnotation] = trimLabel(de.Name)
+	pvc.Annotations[dataExportNameAnnotation] = utils.GetValidLabel(de.Name)
 
 	// If storage class annotation is set , then put that annotation too in the temp pvc
 	// Sometimes the spec.storageclass might be empty, in that case the temp pvc may get the sc as the default sc
@@ -2077,13 +2077,6 @@ func toBoundJobPVCName(pvcName string, pvcUID string) string {
 	}
 	uidToken := strings.Split(pvcUID, "-")
 	return fmt.Sprintf("%s-%s-%s", "bound", truncatedPVCName, uidToken[0])
-}
-
-func trimLabel(label string) string {
-	if len(label) > 63 {
-		return label[:63]
-	}
-	return label
 }
 
 func getRepoPVCName(de *kdmpapi.DataExport, pvcName string) string {

--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -372,7 +372,7 @@ func toRepoName(pvcName, pvcNamespace string) string {
 
 func addVolumeBackupDeleteLabels(jobOpts drivers.JobOpts) map[string]string {
 	labels := make(map[string]string)
-	labels[utils.BackupObjectNameKey] = jobOpts.BackupObjectName
+	labels[utils.BackupObjectNameKey] = utils.GetValidLabel(jobOpts.BackupObjectName)
 	labels[utils.BackupObjectUIDKey] = jobOpts.BackupObjectUID
 	return labels
 }
@@ -383,7 +383,7 @@ func addJobLabels(labels map[string]string, jobOpts drivers.JobOpts) map[string]
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.KopiaDelete
-	labels[utils.BackupObjectNameKey] = jobOpts.BackupObjectName
+	labels[utils.BackupObjectNameKey] = utils.GetValidLabel(jobOpts.BackupObjectName)
 	labels[utils.BackupObjectUIDKey] = jobOpts.BackupObjectUID
 	return labels
 }

--- a/pkg/executor/common.go
+++ b/pkg/executor/common.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -11,13 +12,17 @@ import (
 	"time"
 
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/libopenstorage/stork/pkg/crypto"
+	"github.com/libopenstorage/stork/pkg/log"
 	kdmpapi "github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
 	"github.com/portworx/kdmp/pkg/drivers"
 	"github.com/portworx/kdmp/pkg/drivers/utils"
 	kdmpops "github.com/portworx/kdmp/pkg/util/ops"
+	"github.com/portworx/sched-ops/k8s/core"
 	kdmpschedops "github.com/portworx/sched-ops/k8s/kdmp"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -61,6 +66,19 @@ const (
 	ResticType BackupTool = 0
 	// KopiaType for kopia tool
 	KopiaType BackupTool = 1
+)
+
+const (
+	// MetadataObjectName metadat resource file
+	MetadataObjectName = "metadata.json"
+	// NamespacesFile ns file
+	NamespacesFile = "namespaces.json"
+	// CrdFile crd file
+	CrdFile = "crds.json"
+	// ResourcesFile resources file
+	ResourcesFile = "resources.json"
+	// BackupResourcesBatchCount backup processing batch count
+	BackupResourcesBatchCount = 15
 )
 
 // S3Config specifies the config required to connect to an S3-compliant
@@ -583,4 +601,159 @@ func getShortUID(uid string) string {
 		return ""
 	}
 	return uid[0:7]
+}
+
+// CreateNamespacesFromMapping creates namespace if it's not present
+func CreateNamespacesFromMapping(
+	applicationCRName string,
+	restoreNamespace string) error {
+	funct := "createNamespacesFromMapping"
+	restore, err := storkops.Instance().GetApplicationRestore(applicationCRName, restoreNamespace)
+	if err != nil {
+		logrus.Errorf("%s: Error getting restore cr: %v", funct, err)
+		return err
+	}
+	backup, err := storkops.Instance().GetApplicationBackup(restore.Spec.BackupName, restore.Namespace)
+	if err != nil {
+		log.ApplicationRestoreLog(restore).Errorf("Error getting backup: %v", err)
+		return err
+	}
+	return createNamespaces(backup, restore.Spec.BackupLocation, restore.Namespace, restore)
+}
+
+func createNamespaces(backup *storkapi.ApplicationBackup,
+	backupLocation string,
+	backupLocationNamespace string,
+	restore *storkapi.ApplicationRestore) error {
+	var namespaces []*v1.Namespace
+	funct := "create namespaces"
+
+	repo, err := ParseCloudCred()
+	if err != nil {
+		logrus.Errorf("%s: error parsing cloud cred: %v", funct, err)
+		return err
+	}
+	bkpDir := filepath.Join(repo.Path, backup.Status.BackupPath)
+	restoreLocation, err := storkops.Instance().GetBackupLocation(backup.Spec.BackupLocation, backupLocationNamespace)
+	if err != nil {
+		return err
+	}
+
+	nsData, err := DownloadObject(bkpDir, NamespacesFile, restoreLocation.Location.EncryptionV2Key)
+	if err != nil {
+		return err
+	}
+	if nsData != nil {
+		if err = json.Unmarshal(nsData, &namespaces); err != nil {
+			return err
+		}
+		for _, ns := range namespaces {
+			if restoreNS, ok := restore.Spec.NamespaceMapping[ns.Name]; ok {
+				ns.Name = restoreNS
+			} else {
+				// Skip namespaces we aren't restoring
+				continue
+			}
+			// create mapped restore namespace with metadata of backed up
+			// namespace
+			_, err := core.Instance().CreateNamespace(&v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        ns.Name,
+					Labels:      ns.Labels,
+					Annotations: ns.GetAnnotations(),
+				},
+			})
+			log.ApplicationRestoreLog(restore).Tracef("Creating dest namespace %v", ns.Name)
+			if err != nil {
+				if errors.IsAlreadyExists(err) {
+					oldNS, err := core.Instance().GetNamespace(ns.GetName())
+					if err != nil {
+						return err
+					}
+					annotations := make(map[string]string)
+					labels := make(map[string]string)
+					if restore.Spec.ReplacePolicy == storkapi.ApplicationRestoreReplacePolicyDelete {
+						// overwrite all annotation in case of replace policy set to delete
+						annotations = ns.GetAnnotations()
+						labels = ns.GetLabels()
+					} else if restore.Spec.ReplacePolicy == storkapi.ApplicationRestoreReplacePolicyRetain {
+						// only add new annotation,labels in case of replace policy is set to retain
+						annotations = oldNS.GetAnnotations()
+						if annotations == nil {
+							annotations = make(map[string]string)
+						}
+						for k, v := range ns.GetAnnotations() {
+							if _, ok := annotations[k]; !ok {
+								annotations[k] = v
+							}
+						}
+						labels = oldNS.GetLabels()
+						if labels == nil {
+							labels = make(map[string]string)
+						}
+						for k, v := range ns.GetLabels() {
+							if _, ok := labels[k]; !ok {
+								labels[k] = v
+							}
+						}
+					}
+					log.ApplicationRestoreLog(restore).Tracef("Namespace already exists, updating dest namespace %v", ns.Name)
+					_, err = core.Instance().UpdateNamespace(&v1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        ns.Name,
+							Labels:      labels,
+							Annotations: annotations,
+						},
+					})
+					if err != nil {
+						return err
+					}
+					continue
+				}
+				return err
+			}
+		}
+		return nil
+	}
+	for _, namespace := range restore.Spec.NamespaceMapping {
+		if ns, err := core.Instance().GetNamespace(namespace); err != nil {
+			if errors.IsNotFound(err) {
+				if _, err := core.Instance().CreateNamespace(&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        ns.Name,
+						Labels:      ns.Labels,
+						Annotations: ns.GetAnnotations(),
+					},
+				}); err != nil {
+					return err
+				}
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// DownloadObject download nfs resource object
+func DownloadObject(
+	resourcePath string,
+	resourceFileName string,
+	encryptionKey string,
+) ([]byte, error) {
+	logrus.Debugf("downloadObject resourcePath: %s, resourceFileName: %s", resourcePath, resourceFileName)
+	filePath := filepath.Join(resourcePath, resourceFileName)
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("getting file content of %s failed: %v", filePath, err)
+	}
+
+	if len(encryptionKey) > 0 {
+		var decryptData []byte
+		if decryptData, err = crypto.Decrypt(data, encryptionKey); err != nil {
+			logrus.Errorf("nfs downloadObject: decrypt failed :%v, returning data direclty", err)
+			return data, nil
+		}
+		return decryptData, nil
+	}
+	return data, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
`Added support for creating namespace if not present during vol restore`

**Which issue(s) this PR fixes** (optional)
pb-3278

**Special notes for your reviewer**:
ResourceExport CR created in kube-system ns
ResourceBackup CR created in kube-system ns
PVC creation happens in individual ns

Backup screen shot of two NS 
![Screenshot 2022-11-13 at 10 59 06 PM (2)](https://user-images.githubusercontent.com/51692473/201535461-83707637-07e7-4069-964e-e13552424d70.png)


Restore of the above (to two ns)
![Screenshot 2022-11-13 at 10 59 06 PM (2)](https://user-images.githubusercontent.com/51692473/201535485-b97fde07-7f42-4fbd-9619-051454ecb373.png)

Restoring to one namesapce, backup taken for two ns
![Screenshot 2022-11-13 at 10 31 58 PM (2)](https://user-images.githubusercontent.com/51692473/201556461-ca5b4dcf-2e11-4f78-8fb7-5566bb27e602.png)

Restoring with retain option for existing ns
![Screenshot 2022-11-14 at 6 53 02 AM (2)](https://user-images.githubusercontent.com/51692473/201556545-31432d75-5548-4fa9-915b-c12c00dcd4f6.png)
