### PR TITLE
pb-3216: Taking QPS and burst value from the kdmp-config for nfs executors

### DIFF
--- a/pkg/drivers/utils/common.go
+++ b/pkg/drivers/utils/common.go
@@ -39,6 +39,14 @@ const (
 	KdmpConfigmapNamespace = "kube-system"
 	// DefaultCompresion default compression type
 	DefaultCompresion = "s2-parallel-8"
+	// DefaultQPS - default qps value for k8s apis
+	DefaultQPS = 100
+	// DefaultBurst - default burst value for k8s apis
+	DefaultBurst = 100
+	// QPSKey - configmap QPS key name
+	QPSKey = "K8S_QPS"
+	// BurstKey - configmap burst key name
+	BurstKey = "K8S_BURST"
 )
 
 var (

--- a/pkg/executor/common.go
+++ b/pkg/executor/common.go
@@ -45,10 +45,6 @@ const (
 
 	// DefaultTimeout Max time a command will be retired before failing
 	DefaultTimeout = 1 * time.Minute
-	// QPS Queries per second
-	QPS = 100
-	// Burst value
-	Burst = 100
 	// BackupUID backup UID annotation
 	BackupUID = "portworx.io/backup-uid"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
```
 pb-3216: Taking QPS and burst value from the kdmp-config for nfs executors
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3216

**Special notes for your reviewer**:

