### PR TITLE
pb-3284: Adding git version to nfs executor, travis change to push nfs

### DIFF
--- a/cmd/executor/nfs/nfs.go
+++ b/cmd/executor/nfs/nfs.go
@@ -1,16 +1,21 @@
 package main
 
 import (
+	"os"
+
 	_ "github.com/libopenstorage/stork/drivers/volume/aws"
 	_ "github.com/libopenstorage/stork/drivers/volume/azure"
 	_ "github.com/libopenstorage/stork/drivers/volume/csi"
 	_ "github.com/libopenstorage/stork/drivers/volume/gcp"
 	_ "github.com/libopenstorage/stork/drivers/volume/portworx"
 	nfs_executor "github.com/portworx/kdmp/pkg/executor/nfs"
-	"os"
+	"github.com/portworx/kdmp/pkg/version"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
+	v := version.Get()
+	logrus.Infof("Starting nfs executor: %s, build date %s", v.String(), v.BuildDate)
 	if err := nfs_executor.NewCommand().Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/executor/nfs/nfsbkpresources.go
+++ b/pkg/executor/nfs/nfsbkpresources.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/go-openapi/inflect"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
@@ -148,7 +147,6 @@ func uploadBkpResource(
 		logrus.Errorf(errMsg)
 		return fmt.Errorf(errMsg)
 	}
-	time.Sleep(1 * time.Minute)
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
```
 pb-3284: Adding git version to nfs executor, travis change to push nfs
             executor image
```

**Which issue(s) this PR fixes** (optional)
pb-3284

**Special notes for your reviewer**:
Log showing kdmp git version
```
[root@prashanth-indigo-bear-1 prashanth]# k logs -f -nkube-system nfs-backup-71fe4ce-only-resources-6q47c
+ /nfsexecutor backup --app-cr-name only-resources-4-5aa8237 --backup-namespace only-resources --rb-cr-name nfs-backup-71fe4ce-only-resources --rb-cr-namespace kube-system
^[[A
time="2022-11-14T06:49:25Z" level=info msg="Creating default CSI SnapshotClasses"
W1114 06:49:25.836833       1 warnings.go:70] storage.k8s.io/v1beta1 CSIDriver is deprecated in v1.19+, unavailable in v1.22+; use storage.k8s.io/v1 CSIDriver
time="2022-11-14T06:49:25Z" level=info msg="CSI driver pxd.portworx.com has native support, skipping default snapshotclass creation"
time="2022-11-14T06:49:26Z" level=info msg="Starting nfs: 1.2.3-71d263e2, build date 2022-11-14T06:46:06Z"
time="2022-11-14T06:49:26Z" level=info msg="type: nfs"
time="2022-11-14T06:49:26Z" level=info msg="backup.ObjectMeta.Name: only-resources-4-5aa8237, string(backup.ObjectMeta.UID 71fe4ce8-887a-4664-b554-9c15ed2edb6b"
time="2022-11-14T06:49:26Z" level=info msg="bkpDir: /tmp/nfs-target/only-resources/only-resources-4-5aa8237/71fe4ce8-887a-4664-b554-9c15ed2edb6b"
W1114 06:49:27.953246       1 warnings.go:70] extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
time="2022-11-14T06:49:27Z" level=info msg="metadata: &{Object:map[apiVersion:v1 data:map[name:eGVzdGFjY291bnQ= password:S3ViZXJuZXRlc1JvY2tzIQ==] kind:Secret metadata:map[annotations:map[kubectl.kubernetes.io/last-applied-configuration:{\"apiVersion\":\"v1\",\"data\":{\"name\":\"eGVzdGFjY291bnQ=\",\"password\":\"S3ViZXJuZXRlc1JvY
```
