### PR TITLE
pb-3291: Calling DeleteResources() once for all objects instead of si…

### DIFF
--- a/pkg/executor/nfs/nfsrestorevolcreate.go
+++ b/pkg/executor/nfs/nfsrestorevolcreate.go
@@ -268,20 +268,20 @@ func restoreVolResourcesAndApply(
 						o,
 					)
 				}
-				tempObjects, err := getNamespacedObjectsToDelete(
-					restore,
-					objectBasedOnIncludeResources,
-				)
-				if err != nil {
-					return err
-				}
+			}
+			tempObjects, err := getNamespacedObjectsToDelete(
+				restore,
+				objectBasedOnIncludeResources,
+			)
+			if err != nil {
+				return err
+			}
 
-				err = rc.DeleteResources(
-					dynamicInterface,
-					tempObjects)
-				if err != nil {
-					return err
-				}
+			err = rc.DeleteResources(
+				dynamicInterface,
+				tempObjects)
+			if err != nil {
+				return err
 			}
 		}
 		for _, vInfo := range bkpvInfo {


### PR DESCRIPTION
**What this PR does / why we need it**:
`Calling DeleteResources() once for all objects instead of single object`

**Which issue(s) this PR fixes** (optional)
pb-3291

**Special notes for your reviewer**:
1. Took backup of two PVC in a ns
2. Restored to existing ns which has resoruces.
3. Restore completed in less than 5 mins, with the issue this was taking 20mins

![Screenshot 2022-11-15 at 8 51 36 PM (2)](https://user-images.githubusercontent.com/51692473/201957345-df4f9388-31d8-4e61-81ec-21c140c8c4c8.png)

