### PR TITLE
pb-3290: Updating the totalsize in the appl;cationbackup CR in the job pod itself. So that updated metadata.json will be uploaded to NFS BL.

### DIFF
--- a/pkg/executor/nfs/nfsbkpresources.go
+++ b/pkg/executor/nfs/nfsbkpresources.go
@@ -399,6 +399,10 @@ func uploadMetadatResources(
 	backup.Status.FinishTimestamp = metav1.Now()
 	backup.Status.Status = stork_api.ApplicationBackupStatusSuccessful
 	backup.Status.Reason = "Volumes and resources were backed up successfully"
+	// Only on success compute the total backup size
+	for _, vInfo := range backup.Status.Volumes {
+		backup.Status.TotalSize += vInfo.TotalSize
+	}
 
 	jsonBytes, err := json.MarshalIndent(backup, "", " ")
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-3290: Updating the totalsize in the appl;cationbackup CR in the job pod itself. So that updated metadata.json will be uploaded to NFS BL.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3290

**Special notes for your reviewer**:
Tested on QA system.

