### PR TITLE
pb-3317: Avoiding the pod count for the pvc usage for live backup calculation, if it is used by kdmp job pods.

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -540,7 +540,15 @@ func (c *Controller) createJobCredCertSecrets(
 			}
 			return data, err
 		}
-		if len(pods) > 0 {
+		// filter out the pods that are create by us
+		count := len(pods)
+		for _, pod := range pods {
+			labels := pod.ObjectMeta.Labels
+			if _, ok := labels[drivers.DriverNameLabel]; ok {
+				count--
+			}
+		}
+		if count > 0 {
 			namespace = utils.AdminNamespace
 		}
 		blName = dataExport.Spec.Destination.Name

--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -448,7 +448,15 @@ func buildJob(jobName string, jobOptions drivers.JobOpts) (*batchv1.Job, error) 
 	}
 	var resourceNamespace string
 	var live bool
-	if len(pods) > 0 {
+	// filter out the pods that are create by us
+	count := len(pods)
+	for _, pod := range pods {
+		labels := pod.ObjectMeta.Labels
+		if _, ok := labels[drivers.DriverNameLabel]; ok {
+			count--
+		}
+	}
+	if count > 0 {
 		resourceNamespace = utils.AdminNamespace
 		live = true
 	} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-3317: Avoiding the pod count for the pvc usage for live backup
    calculation, if it is used by kdmp job pods.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3317

**Special notes for your reviewer**:
Tested with four parallel backup o
![Screenshot 2022-11-20 at 1 11 38 PM](https://user-images.githubusercontent.com/52188641/202891321-f5fcad8a-67ec-4aef-be1a-7ac04a6fdd00.png)
n same namespace.

