### PR TITLE
pb-3217: cleaned up the corba command option for nfs executor.

### DIFF
--- a/pkg/executor/nfs/nfs.go
+++ b/pkg/executor/nfs/nfs.go
@@ -24,11 +24,6 @@ func NewCommand() *cobra.Command {
 		Short: "a command executor for nfs target as support ",
 	}
 
-	cmds.PersistentFlags().StringVarP(&restoreNamespace, "restore-namespace", "", "", "Namespace for restore CR")
-	cmds.PersistentFlags().StringVarP(&appRestoreCRName, "app-cr-name", "", "", "application restore CR name")
-	cmds.PersistentFlags().StringVarP(&rbCrName, "rb-cr-name", "", "", "Name for resourcebackup CR to update job status")
-	cmds.PersistentFlags().StringVarP(&rbCrNamespace, "rb-cr-namespace", "", "", "Namespace for resourcebackup CR to update job status")
-
 	cmds.AddCommand(
 		newUploadBkpResourceCommand(),
 		newRestoreResourcesCommand(),

--- a/pkg/executor/nfs/nfsbkpresources.go
+++ b/pkg/executor/nfs/nfsbkpresources.go
@@ -54,6 +54,8 @@ func newUploadBkpResourceCommand() *cobra.Command {
 	}
 	bkpUploadCommand.Flags().StringVarP(&bkpNamespace, "backup-namespace", "", "", "Namespace for backup command")
 	bkpUploadCommand.Flags().StringVarP(&appBackupCRName, "app-cr-name", "", "", "Namespace for applicationbackup CR whose resource to be backed up")
+	bkpUploadCommand.PersistentFlags().StringVarP(&rbCrName, "rb-cr-name", "", "", "Name for resourcebackup CR to update job status")
+	bkpUploadCommand.PersistentFlags().StringVarP(&rbCrNamespace, "rb-cr-namespace", "", "", "Namespace for resourcebackup CR to update job status")
 
 	return bkpUploadCommand
 }

--- a/pkg/executor/nfs/nfsrestorevolcreate.go
+++ b/pkg/executor/nfs/nfsrestorevolcreate.go
@@ -59,6 +59,10 @@ func newRestoreVolumeCommand() *cobra.Command {
 			executor.HandleErr(restoreVolResourcesAndApply(appRestoreCRName, restoreNamespace, rbCrName, rbCrNamespace))
 		},
 	}
+		restoreCommand.PersistentFlags().StringVarP(&restoreNamespace, "restore-namespace", "", "", "Namespace for restore CR")
+		restoreCommand.PersistentFlags().StringVarP(&appRestoreCRName, "app-cr-name", "", "", "application restore CR name")
+		restoreCommand.PersistentFlags().StringVarP(&rbCrName, "rb-cr-name", "", "", "Name for resourcebackup CR to update job status")
+		restoreCommand.PersistentFlags().StringVarP(&rbCrNamespace, "rb-cr-namespace", "", "", "Namespace for resourcebackup CR to update job status")
 
 	return restoreCommand
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-3217: cleaned up the corba command option for nfs executor.

            - Currently there is no common command parameter in different
              operation. So remove the definition from nfs.go.
            - Added required parameter in the individual files itself.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3217

**Special notes for your reviewer**:
Tested basic backup and restore with mysql.
