### PR TITLE
pb-3298: Added check not to check for service account secret token from 1.24.0 k8s onwards.

### DIFF
--- a/pkg/drivers/utils/common.go
+++ b/pkg/drivers/utils/common.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	version "github.com/hashicorp/go-version"
+	storkversion "github.com/libopenstorage/stork/pkg/version"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 	rbacops "github.com/portworx/sched-ops/k8s/rbac"
 	"github.com/portworx/sched-ops/task"
@@ -46,13 +48,31 @@ const (
 	// QPSKey - configmap QPS key name
 	QPSKey = "K8S_QPS"
 	// BurstKey - configmap burst key name
-	BurstKey = "K8S_BURST"
+	BurstKey                             = "K8S_BURST"
+	k8sMinVersionSASecretTokenNotSupport = "1.24"
 )
 
 var (
 	// JobPodBackOffLimit backofflimit for the job
 	JobPodBackOffLimit = int32(10)
 )
+
+// isServiceAccountSecretMissing returns true, if the K8s version does not support secret token for the service account.
+func isServiceAccountSecretMissing() (bool, error) {
+	k8sVersion, _, err := storkversion.GetFullVersion()
+	if err != nil {
+		return false, err
+	}
+	VersionTokenNotSupported, err := version.NewVersion(k8sMinVersionSASecretTokenNotSupport)
+	if err != nil {
+		return false, err
+
+	}
+	if k8sVersion.GreaterThanOrEqual(VersionTokenNotSupported) {
+		return true, nil
+	}
+	return false, nil
+}
 
 // SetupServiceAccount create a service account and bind it to a provided role.
 func SetupServiceAccount(name, namespace string, role *rbacv1.Role) error {
@@ -73,35 +93,39 @@ func SetupServiceAccount(name, namespace string, role *rbacv1.Role) error {
 	if sa, err = coreops.Instance().CreateServiceAccount(serviceAccountFor(name, namespace)); err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("create %s/%s serviceaccount: %s", namespace, name, err)
 	}
-	t := func() (interface{}, bool, error) {
-		sa, err = coreops.Instance().GetServiceAccount(name, namespace)
-		if err != nil {
-			errMsg := fmt.Sprintf("failed fetching sa [%v/%v]: %v", name, namespace, err)
-			logrus.Tracef("%v", errMsg)
-			return "", true, fmt.Errorf("%v", errMsg)
+	// From 1.24.0 onwards service token does not support default secret token
+	tokenSupported, err := isServiceAccountSecretMissing()
+	if !tokenSupported {
+		t := func() (interface{}, bool, error) {
+			sa, err = coreops.Instance().GetServiceAccount(name, namespace)
+			if err != nil {
+				errMsg := fmt.Sprintf("failed fetching sa [%v/%v]: %v", name, namespace, err)
+				logrus.Tracef("%v", errMsg)
+				return "", true, fmt.Errorf("%v", errMsg)
+			}
+			if sa.Secrets == nil {
+				errMsg := fmt.Sprintf("secret token is missing in sa [%v/%v]", name, namespace)
+				return "", true, fmt.Errorf("%v", errMsg)
+			}
+			return "", false, nil
 		}
-		if sa.Secrets == nil {
-			errMsg := fmt.Sprintf("secret token is missing in sa [%v/%v]", name, namespace)
-			return "", true, fmt.Errorf("%v", errMsg)
+		if _, err := task.DoRetryWithTimeout(t, DefaultTimeout, ProgressCheckInterval); err != nil {
+			errMsg := fmt.Sprintf("max retries done, failed in fetching secret token of sa [%v/%v]: %v ", name, namespace, err)
+			logrus.Errorf("%v", errMsg)
+			// Exhausted all retries
+			return err
 		}
-		return "", false, nil
-	}
-	if _, err := task.DoRetryWithTimeout(t, DefaultTimeout, ProgressCheckInterval); err != nil {
-		errMsg := fmt.Sprintf("max retries done, failed in fetching secret token of sa [%v/%v]: %v ", name, namespace, err)
-		logrus.Errorf("%v", errMsg)
-		// Exhausted all retries
-		return err
-	}
 
-	tokenName := sa.Secrets[0].Name
-	secretToken, err := coreops.Instance().GetSecret(tokenName, namespace)
-	if err != nil {
-		return fmt.Errorf("failed in getting secretToken [%v] of service account [%v/%v]: %v", tokenName, name, namespace, err)
-	}
-	secretToken.Annotations[SkipResourceAnnotation] = "true"
-	_, err = coreops.Instance().UpdateSecret(secretToken)
-	if err != nil {
-		return fmt.Errorf("failed in updating the secretToken [%v] of service account [%v/%v]: %v", tokenName, name, namespace, err)
+		tokenName := sa.Secrets[0].Name
+		secretToken, err := coreops.Instance().GetSecret(tokenName, namespace)
+		if err != nil {
+			return fmt.Errorf("failed in getting secretToken [%v] of service account [%v/%v]: %v", tokenName, name, namespace, err)
+		}
+		secretToken.Annotations[SkipResourceAnnotation] = "true"
+		_, err = coreops.Instance().UpdateSecret(secretToken)
+		if err != nil {
+			return fmt.Errorf("failed in updating the secretToken [%v] of service account [%v/%v]: %v", tokenName, name, namespace, err)
+		}
 	}
 	return nil
 }
@@ -140,40 +164,44 @@ func SetupNFSServiceAccount(name, namespace string, role *rbacv1.ClusterRole) er
 		return fmt.Errorf("create %s/%s serviceaccount: %s", namespace, name, err)
 	}
 	var errMsg error
-	t := func() (interface{}, bool, error) {
-		sa, err = coreops.Instance().GetServiceAccount(name, namespace)
-		if err != nil {
-			errMsg = fmt.Errorf("failed fetching sa [%v/%v]: %v", name, namespace, err)
-			logrus.Errorf("%v", errMsg)
-			return "", true, fmt.Errorf("%v", errMsg)
+	// From 1.24.0 onwards service token does not support default secret token
+	tokenSupported, err := isServiceAccountSecretMissing()
+	if !tokenSupported {
+		t := func() (interface{}, bool, error) {
+			sa, err = coreops.Instance().GetServiceAccount(name, namespace)
+			if err != nil {
+				errMsg = fmt.Errorf("failed fetching sa [%v/%v]: %v", name, namespace, err)
+				logrus.Errorf("%v", errMsg)
+				return "", true, fmt.Errorf("%v", errMsg)
+			}
+			if sa.Secrets == nil {
+				logrus.Infof("Returned sa-secret null")
+				errMsg = fmt.Errorf("secret token is missing in sa [%v/%v]", name, namespace)
+				return "", true, fmt.Errorf("%v", errMsg)
+			}
+			return "", false, nil
 		}
-		if sa.Secrets == nil {
-			logrus.Infof("Returned sa-secret null")
-			errMsg = fmt.Errorf("secret token is missing in sa [%v/%v]", name, namespace)
-			return "", true, fmt.Errorf("%v", errMsg)
+		if _, err := task.DoRetryWithTimeout(t, DefaultTimeout, ProgressCheckInterval); err != nil {
+			eMsg := fmt.Errorf("max retries done, failed in fetching secret token of sa [%v/%v]: %v ", name, namespace, errMsg)
+			logrus.Errorf("%v", eMsg)
+			// Exhausted all retries
+			return eMsg
 		}
-		return "", false, nil
-	}
-	if _, err := task.DoRetryWithTimeout(t, DefaultTimeout, ProgressCheckInterval); err != nil {
-		eMsg := fmt.Errorf("max retries done, failed in fetching secret token of sa [%v/%v]: %v ", name, namespace, errMsg)
-		logrus.Errorf("%v", eMsg)
-		// Exhausted all retries
-		return eMsg
-	}
 
-	tokenName := sa.Secrets[0].Name
-	secretToken, err := coreops.Instance().GetSecret(tokenName, namespace)
-	if err != nil {
-		errMsg := fmt.Errorf("failed in getting secretToken [%v] of service account [%v/%v]: %v", tokenName, name, namespace, err)
-		logrus.Errorf("%v", errMsg)
-		return errMsg
-	}
-	secretToken.Annotations[SkipResourceAnnotation] = "true"
-	_, err = coreops.Instance().UpdateSecret(secretToken)
-	if err != nil {
-		errMsg := fmt.Errorf("failed in updating the secretToken [%v] of service account [%v/%v]: %v", tokenName, name, namespace, err)
-		logrus.Errorf("%v", errMsg)
-		return errMsg
+		tokenName := sa.Secrets[0].Name
+		secretToken, err := coreops.Instance().GetSecret(tokenName, namespace)
+		if err != nil {
+			errMsg := fmt.Errorf("failed in getting secretToken [%v] of service account [%v/%v]: %v", tokenName, name, namespace, err)
+			logrus.Errorf("%v", errMsg)
+			return errMsg
+		}
+		secretToken.Annotations[SkipResourceAnnotation] = "true"
+		_, err = coreops.Instance().UpdateSecret(secretToken)
+		if err != nil {
+			errMsg := fmt.Errorf("failed in updating the secretToken [%v] of service account [%v/%v]: %v", tokenName, name, namespace, err)
+			logrus.Errorf("%v", errMsg)
+			return errMsg
+		}
 	}
 	return nil
 }

--- a/pkg/executor/nfs/nfsbkpresources.go
+++ b/pkg/executor/nfs/nfsbkpresources.go
@@ -151,7 +151,7 @@ func uploadBkpResource(
 		return fmt.Errorf(errMsg)
 	}
 	return nil
-	
+
 }
 
 func uploadResource(


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-3298: Added check not to check for service account secret token from 1.24.0 k8s onwards
```
**Which issue(s) this PR fixes** (optional)
Closes #pb-3298

**Special notes for your reviewer**:
Tested by vendor to the stork and kdmp backup.
