### PR TITLE
pb-3447: Added uploadCSISnapshots to upload the snapshot.json as part of nfs executor job.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7
-	github.com/libopenstorage/stork v1.4.1-0.20230208122050-965b4be91e93
+	github.com/libopenstorage/stork v1.4.1-0.20230216111318-15ed8c1a7d43
 	github.com/portworx/pxc v0.33.0
 	github.com/portworx/sched-ops v1.20.4-rc1.0.20230207071213-7a8e221c9ebf
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1775,8 +1775,8 @@ github.com/libopenstorage/stork v1.4.1-0.20220323180113-0ea773109d05/go.mod h1:h
 github.com/libopenstorage/stork v1.4.1-0.20220414104250-3c18fd21ed95/go.mod h1:yE94X0xBFSBQ9LvvJ/zppc4+XeiCAXtsHfYHm15dlcA=
 github.com/libopenstorage/stork v1.4.1-0.20221103082056-65abc8cc4e80/go.mod h1:yX+IlCrUsZekC6zxL6zHE7sBPKIudubHB3EcImzeRbI=
 github.com/libopenstorage/stork v1.4.1-0.20230207013129-a31284f0e973/go.mod h1:/EFTTQyBxNzul96urrYPdjNEYeDzVgZzK88gRQjoVmk=
-github.com/libopenstorage/stork v1.4.1-0.20230208122050-965b4be91e93 h1:WRPqv2YaaEzkdHqzx1bxWJXPd6IqeUNGzKwe5FjWQpw=
-github.com/libopenstorage/stork v1.4.1-0.20230208122050-965b4be91e93/go.mod h1:T19yWS9FaiyM38aagBJ6rwHDB5EJB8TS8NdcP99CRwQ=
+github.com/libopenstorage/stork v1.4.1-0.20230216111318-15ed8c1a7d43 h1:qCPd0OOr5Xprvh4Pnw0xa18T4Z2uYt4mRDW3i1/d/s8=
+github.com/libopenstorage/stork v1.4.1-0.20230216111318-15ed8c1a7d43/go.mod h1:Yk122oBhH8yC5Pm7vmda5a3GI3wCxQpuonScZG4Ewew=
 github.com/libopenstorage/systemutils v0.0.0-20160208220149-44ac83be3ce1/go.mod h1:xwNGC7xiz/BQ/wbMkvHujL8Gjgseg+x41xMek7sKRRQ=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=

--- a/pkg/executor/nfs/nfsbkpresources.go
+++ b/pkg/executor/nfs/nfsbkpresources.go
@@ -200,7 +200,7 @@ func uploadResource(
 	allObjects := make([]runtime.Unstructured, 0)
 	for i := 0; i < len(backup.Spec.Namespaces); i += backupResourcesBatchCount {
 		batch := backup.Spec.Namespaces[i:min(i+backupResourcesBatchCount, len(backup.Spec.Namespaces))]
-		objects, err := rc.GetResources(
+		objects, _, err := rc.GetResources(
 			batch,
 			backup.Spec.Selectors,
 			dummyObjects,

--- a/vendor/github.com/libopenstorage/stork/drivers/volume/csi/csi.go
+++ b/vendor/github.com/libopenstorage/stork/drivers/volume/csi/csi.go
@@ -40,17 +40,17 @@ import (
 )
 
 const (
-	// snapshotPrefix is appended to CSI backup snapshot
-	snapshotBackupPrefix = "backup"
-	// snapshotPrefix is appended to CSI restore snapshot
+	// SnapshotBackupPrefix is appended to CSI backup snapshot
+	SnapshotBackupPrefix = "backup"
+	// snapshotRestorePrefix is appended to CSI restore snapshot
 	snapshotRestorePrefix = "restore"
 	// snapshotClassNamePrefix is the prefix for snapshot classes per CSI driver
 	snapshotClassNamePrefix = "stork-csi-snapshot-class-"
 
-	// snapshotObjectName is the object stored for the volumesnapshot
-	snapshotObjectName = "snapshots.json"
-	// storageClassesObjectName is the object stored for storageclasses
-	storageClassesObjectName = "storageclasses.json"
+	// SnapshotObjectName is the object stored for the volumesnapshot
+	SnapshotObjectName = "snapshots.json"
+	// StorageClassesObjectName is the object stored for storageclasses
+	StorageClassesObjectName = "storageclasses.json"
 	// resourcesObjectName is the object stored for the all backup resources
 	resourcesObjectName = "resources.json"
 
@@ -66,12 +66,12 @@ const (
 	restoreUIDLabel        = "restoreUID"
 )
 
-// csiBackupObject represents a backup of a series of CSI objects
-type csiBackupObject struct {
+// CsiBackupObject represents a backup of a series of CSI objects
+type CsiBackupObject struct {
 	VolumeSnapshots          interface{} `json:"volumeSnapshots"`
 	VolumeSnapshotContents   interface{} `json:"volumeSnapshotContents"`
 	VolumeSnapshotClasses    interface{} `json:"volumeSnapshotClasses"`
-	v1VolumeSnapshotRequired bool
+	V1VolumeSnapshotRequired bool
 }
 
 // BackupObjectv1Csi represents a backup of a series of v1 VolumeSnapshot CSI objects
@@ -91,11 +91,11 @@ type BackupObjectv1beta1Csi struct {
 }
 
 // GetVolumeSnapshotContent retrieves a backed up volume snapshot
-func (cbo *csiBackupObject) GetVolumeSnapshot(snapshotID string) (interface{}, error) {
+func (cbo *CsiBackupObject) GetVolumeSnapshot(snapshotID string) (interface{}, error) {
 	var vs interface{}
 	var ok bool
 
-	if cbo.v1VolumeSnapshotRequired {
+	if cbo.V1VolumeSnapshotRequired {
 		vs, ok = cbo.VolumeSnapshots.(map[string]*kSnapshotv1.VolumeSnapshot)[snapshotID]
 	} else {
 		vs, ok = cbo.VolumeSnapshots.(map[string]*kSnapshotv1beta1.VolumeSnapshot)[snapshotID]
@@ -107,11 +107,11 @@ func (cbo *csiBackupObject) GetVolumeSnapshot(snapshotID string) (interface{}, e
 }
 
 // GetVolumeSnapshotContent retrieves a backed up volume snapshot content
-func (cbo *csiBackupObject) GetVolumeSnapshotContent(snapshotID string) (interface{}, error) {
+func (cbo *CsiBackupObject) GetVolumeSnapshotContent(snapshotID string) (interface{}, error) {
 	var vsc interface{}
 	var ok bool
 
-	if cbo.v1VolumeSnapshotRequired {
+	if cbo.V1VolumeSnapshotRequired {
 		vsc, ok = cbo.VolumeSnapshotContents.(map[string]*kSnapshotv1.VolumeSnapshotContent)[snapshotID]
 	} else {
 		vsc, ok = cbo.VolumeSnapshotContents.(map[string]*kSnapshotv1beta1.VolumeSnapshotContent)[snapshotID]
@@ -123,12 +123,12 @@ func (cbo *csiBackupObject) GetVolumeSnapshotContent(snapshotID string) (interfa
 }
 
 // GetVolumeSnapshotClass retrieves a backed up volume snapshot class
-func (cbo *csiBackupObject) GetVolumeSnapshotClass(snapshotID string) (interface{}, error) {
+func (cbo *CsiBackupObject) GetVolumeSnapshotClass(snapshotID string) (interface{}, error) {
 	var vsClass, vs interface{}
 	var vsClassName string
 	var ok bool
 
-	if cbo.v1VolumeSnapshotRequired {
+	if cbo.V1VolumeSnapshotRequired {
 		vs, ok = cbo.VolumeSnapshots.(map[string]*kSnapshotv1.VolumeSnapshot)[snapshotID]
 		if !ok {
 			logrus.Errorf("failed to retrieve volume snapshot for snapshot ID %s", snapshotID)
@@ -312,10 +312,6 @@ func (c *csi) OwnsPVCForBackup(
 	crBackupType string,
 	blType storkapi.BackupLocationType,
 ) bool {
-	// For CSI volume and backuplocation type is NFS, It will default to kdmp
-	if blType == storkapi.BackupLocationNFS {
-		return false
-	}
 	if cmBackupType == storkapi.ApplicationBackupGeneric || crBackupType == storkapi.ApplicationBackupGeneric {
 		// If user has forced the backupType in config map or applicationbackup CR, default to generic always
 		return false
@@ -455,7 +451,7 @@ func (c *csi) backupStorageClasses(storageClasses []*storagev1.StorageClass, bac
 		return err
 	}
 
-	err = c.uploadObject(backup, storageClassesObjectName, scBytes)
+	err = c.uploadObject(backup, StorageClassesObjectName, scBytes)
 	if err != nil {
 		return err
 	}
@@ -553,7 +549,7 @@ func (c *csi) StartBackup(
 }
 
 func (c *csi) getBackupSnapshotName(pvc *v1.PersistentVolumeClaim, backup *storkapi.ApplicationBackup) string {
-	return fmt.Sprintf("%s-%s-%s", snapshotBackupPrefix, getUIDLastSection(backup.UID), getUIDLastSection(pvc.UID))
+	return fmt.Sprintf("%s-%s-%s", SnapshotBackupPrefix, utils.GetUIDLastSection(backup.UID), utils.GetUIDLastSection(pvc.UID))
 }
 
 // uploadObject uploads the given data to the backup location specified in the backup object
@@ -614,18 +610,18 @@ func (c *csi) uploadCSIBackupObject(
 		return fmt.Errorf("failed to get volumesnapshot version supported by cluster")
 	}
 	if v1VolumeSnapshotRequired {
-		csiBackup = csiBackupObject{
+		csiBackup = CsiBackupObject{
 			VolumeSnapshots:          vsMap.(map[string]*kSnapshotv1.VolumeSnapshot),
 			VolumeSnapshotContents:   vsContentMap.(map[string]*kSnapshotv1.VolumeSnapshotContent),
 			VolumeSnapshotClasses:    vsClassMap.(map[string]*kSnapshotv1.VolumeSnapshotClass),
-			v1VolumeSnapshotRequired: true,
+			V1VolumeSnapshotRequired: true,
 		}
 	} else {
-		csiBackup = csiBackupObject{
+		csiBackup = CsiBackupObject{
 			VolumeSnapshots:          vsMap.(map[string]*kSnapshotv1beta1.VolumeSnapshot),
 			VolumeSnapshotContents:   vsContentMap.(map[string]*kSnapshotv1beta1.VolumeSnapshotContent),
 			VolumeSnapshotClasses:    vsClassMap.(map[string]*kSnapshotv1beta1.VolumeSnapshotClass),
-			v1VolumeSnapshotRequired: false,
+			V1VolumeSnapshotRequired: false,
 		}
 	}
 
@@ -636,7 +632,7 @@ func (c *csi) uploadCSIBackupObject(
 		return err
 	}
 
-	err = c.uploadObject(backup, snapshotObjectName, csiBackupBytes)
+	err = c.uploadObject(backup, SnapshotObjectName, csiBackupBytes)
 	if err != nil {
 		return err
 	}
@@ -809,6 +805,7 @@ func (c *csi) cleanupSnapshots(
 }
 
 func (c *csi) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.ApplicationBackupVolumeInfo, error) {
+	funct := "csi GetBackupStatus"
 	if c.snapshotClient == nil {
 		if err := c.Init(nil); err != nil {
 			return nil, err
@@ -954,13 +951,23 @@ func (c *csi) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 		vsMapLen = len(vsMap.(map[string]*kSnapshotv1beta1.VolumeSnapshot))
 		vsContentMapLen = len(vsContentMap.(map[string]*kSnapshotv1beta1.VolumeSnapshotContent))
 	}
-	// if all have finished, add all VolumeSnapshot and VolumeSnapshotContent to objectstore
-	if !anyInProgress && vsContentMapLen > 0 && vsMapLen > 0 {
-		err := c.uploadCSIBackupObject(backup, vsMap, vsContentMap, vsClassMap)
-		if err != nil {
-			return nil, err
+
+	nfs, err := utils.IsNFSBackuplocationType(backup.Namespace, backup.Spec.BackupLocation)
+	if err != nil {
+		logrus.Errorf("%v error in checking backuplocation type: %v", funct, err)
+		return nil, err
+	}
+	// In the case of nfs backuplocation type, uploading of snapshot.json will
+	// happen as part of resource exexutor job as part of resource stage.
+	if !nfs {
+		// if all have finished, add all VolumeSnapshot and VolumeSnapshotContent to objectstore
+		if !anyInProgress && vsContentMapLen > 0 && vsMapLen > 0 {
+			err := c.uploadCSIBackupObject(backup, vsMap, vsContentMap, vsClassMap)
+			if err != nil {
+				return nil, err
+			}
+			log.ApplicationBackupLog(backup).Debugf("finished and uploaded %v snapshots and %v snapshotcontents", vsMapLen, vsContentMapLen)
 		}
-		log.ApplicationBackupLog(backup).Debugf("finished and uploaded %v snapshots and %v snapshotcontents", vsMapLen, vsContentMapLen)
 	}
 	return volumeInfos, nil
 }
@@ -968,7 +975,7 @@ func (c *csi) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 func (c *csi) recreateSnapshotForDeletion(
 	backup *storkapi.ApplicationBackup,
 	vbInfo *storkapi.ApplicationBackupVolumeInfo,
-	csiBackupObject *csiBackupObject,
+	csiBackupObject *CsiBackupObject,
 	snapshotClassCreatedForDriver map[string]bool,
 ) error {
 	var err error
@@ -1114,10 +1121,10 @@ func (c *csi) cleanupBackupLocation(backup *storkapi.ApplicationBackup) error {
 
 	objectPath := backup.Status.BackupPath
 	if objectPath != "" {
-		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, snapshotObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
+		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, SnapshotObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
 			return fmt.Errorf("error deleting resources for backup %v/%v: %v", backup.Namespace, backup.Name, err)
 		}
-		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, storageClassesObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
+		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, StorageClassesObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
 			return fmt.Errorf("error deleting resources for backup %v/%v: %v", backup.Namespace, backup.Name, err)
 		}
 	}
@@ -1195,7 +1202,7 @@ func (c *csi) UpdateMigratedPersistentVolumeSpec(
 
 func (c *csi) getRestoreStorageClasses(backup *storkapi.ApplicationBackup, resources []runtime.Unstructured) ([]runtime.Unstructured, error) {
 	storageClasses := make([]storagev1.StorageClass, 0)
-	storageClassesBytes, err := c.downloadObject(backup, backup.Spec.BackupLocation, backup.Namespace, storageClassesObjectName)
+	storageClassesBytes, err := c.downloadObject(backup, backup.Spec.BackupLocation, backup.Namespace, StorageClassesObjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -1272,17 +1279,17 @@ func (c *csi) downloadObject(
 
 // getRestoreSnapshotsAndContent retrieves the volumeSnapshots and
 // volumeSnapshotContents associated with a backupID
-func (c *csi) getCSIBackupObject(backupName, backupNamespace string) (*csiBackupObject, error) {
+func (c *csi) getCSIBackupObject(backupName, backupNamespace string) (*CsiBackupObject, error) {
 	backup, err := storkops.Instance().GetApplicationBackup(backupName, backupNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("error getting backup spec for CSI restore: %v", err)
 	}
 
-	backupObjectBytes, err := c.downloadObject(backup, backup.Spec.BackupLocation, backup.Namespace, snapshotObjectName)
+	backupObjectBytes, err := c.downloadObject(backup, backup.Spec.BackupLocation, backup.Namespace, SnapshotObjectName)
 	if err != nil {
 		return nil, err
 	}
-	cboCommon := &csiBackupObject{}
+	cboCommon := &CsiBackupObject{}
 	if c.v1SnapshotRequired {
 		cbov1 := &BackupObjectv1Csi{}
 		err = json.Unmarshal(backupObjectBytes, cbov1)
@@ -1292,7 +1299,7 @@ func (c *csi) getCSIBackupObject(backupName, backupNamespace string) (*csiBackup
 		cboCommon.VolumeSnapshots = cbov1.VolumeSnapshots
 		cboCommon.VolumeSnapshotContents = cbov1.VolumeSnapshotContents
 		cboCommon.VolumeSnapshotClasses = cbov1.VolumeSnapshotClasses
-		cboCommon.v1VolumeSnapshotRequired = c.v1SnapshotRequired
+		cboCommon.V1VolumeSnapshotRequired = c.v1SnapshotRequired
 		return cboCommon, nil
 	}
 	cbov1beta1 := &BackupObjectv1beta1Csi{}
@@ -1303,7 +1310,7 @@ func (c *csi) getCSIBackupObject(backupName, backupNamespace string) (*csiBackup
 	cboCommon.VolumeSnapshots = cbov1beta1.VolumeSnapshots
 	cboCommon.VolumeSnapshotContents = cbov1beta1.VolumeSnapshotContents
 	cboCommon.VolumeSnapshotClasses = cbov1beta1.VolumeSnapshotClasses
-	cboCommon.v1VolumeSnapshotRequired = c.v1SnapshotRequired
+	cboCommon.V1VolumeSnapshotRequired = c.v1SnapshotRequired
 
 	return cboCommon, nil
 }
@@ -1495,7 +1502,7 @@ func (c *csi) restoreVolumeSnapshotContent(
 	return vsc, nil
 }
 
-func getUIDLastSection(uid types.UID) string {
+func GetUIDLastSection(uid types.UID) string {
 	parts := strings.Split(string(uid), "-")
 	uidLastSection := parts[len(parts)-1]
 
@@ -1506,17 +1513,17 @@ func getUIDLastSection(uid types.UID) string {
 }
 
 func (c *csi) getRestoreSnapshotName(existingSnapshotUID types.UID, restoreUID types.UID) string {
-	return fmt.Sprintf("%s-vs-%s-%s", snapshotRestorePrefix, getUIDLastSection(restoreUID), getUIDLastSection(existingSnapshotUID))
+	return fmt.Sprintf("%s-vs-%s-%s", snapshotRestorePrefix, utils.GetUIDLastSection(restoreUID), utils.GetUIDLastSection(existingSnapshotUID))
 }
 
 func (c *csi) getRestoreSnapshotContentName(existingSnapshotUID types.UID, restoreUID types.UID) string {
-	return fmt.Sprintf("%s-vsc-%s-%s", snapshotRestorePrefix, getUIDLastSection(restoreUID), getUIDLastSection(existingSnapshotUID))
+	return fmt.Sprintf("%s-vsc-%s-%s", snapshotRestorePrefix, utils.GetUIDLastSection(restoreUID), utils.GetUIDLastSection(existingSnapshotUID))
 }
 
 func (c *csi) createRestoreSnapshotsAndPVCs(
 	restore *storkapi.ApplicationRestore,
 	volumeBackupInfos []*storkapi.ApplicationBackupVolumeInfo,
-	csiBackupObject *csiBackupObject,
+	csiBackupObject *CsiBackupObject,
 ) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
 	var err error
 	volumeRestoreInfos := []*storkapi.ApplicationRestoreVolumeInfo{}

--- a/vendor/github.com/libopenstorage/stork/drivers/volume/portworx/portworx.go
+++ b/vendor/github.com/libopenstorage/stork/drivers/volume/portworx/portworx.go
@@ -688,11 +688,6 @@ func (p *portworx) GetClusterID() (string, error) {
 }
 
 func (p *portworx) OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, cmBackupType string, crBackupType string, blType storkapi.BackupLocationType) bool {
-	// For portworx volume and backuplocation type is NFS, we will not own.
-	// It will default to kdmp
-	if blType == storkapi.BackupLocationNFS {
-		return false
-	}
 	return p.IsSupportedPVC(coreOps, pvc, true)
 }
 

--- a/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1253,7 +1253,7 @@ func (a *ApplicationBackupController) backupResources(
 			}
 		}
 		if len(incResNsBatch) != 0 {
-			objects, err := a.resourceCollector.GetResources(
+			objects, _, err := a.resourceCollector.GetResources(
 				incResNsBatch,
 				backup.Spec.Selectors,
 				objectMap,
@@ -1273,7 +1273,7 @@ func (a *ApplicationBackupController) backupResources(
 				for _, resource := range resourceTypes {
 					if resource.Kind == backupResourceType || (backupResourceType == "PersistentVolumeClaim" && resource.Kind == "PersistentVolume") {
 						log.ApplicationBackupLog(backup).Tracef("GetResourcesType for : %v", resource.Kind)
-						objects, err := a.resourceCollector.GetResourcesForType(resource, nil, resourceTypeNsBatch, backup.Spec.Selectors, nil, true, resourceCollectorOpts)
+						objects, _, err := a.resourceCollector.GetResourcesForType(resource, nil, resourceTypeNsBatch, backup.Spec.Selectors, nil, true, resourceCollectorOpts)
 						if err != nil {
 							log.ApplicationBackupLog(backup).Errorf("Error getting resources: %v", err)
 							return err

--- a/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationclone.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationclone.go
@@ -753,7 +753,7 @@ func (a *ApplicationCloneController) applyResources(
 func (a *ApplicationCloneController) cloneResources(
 	clone *stork_api.ApplicationClone,
 ) error {
-	allObjects, err := a.resourceCollector.GetResources(
+	allObjects, _, err := a.resourceCollector.GetResources(
 		[]string{clone.Spec.SourceNamespace},
 		clone.Spec.Selectors,
 		nil,

--- a/vendor/github.com/libopenstorage/stork/pkg/resourcecollector/resourcecollector.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/resourcecollector/resourcecollector.go
@@ -8,18 +8,19 @@ import (
 	"strings"
 	"time"
 
-	storkcache "github.com/libopenstorage/stork/pkg/cache"
-	rbacv1 "k8s.io/api/rbac/v1"
-
 	"github.com/go-openapi/inflect"
 	"github.com/heptio/ark/pkg/discovery"
 	"github.com/libopenstorage/stork/drivers/volume"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	storkcache "github.com/libopenstorage/stork/pkg/cache"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/rbac"
 	"github.com/portworx/sched-ops/k8s/storage"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
+
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -221,7 +222,7 @@ func (r *ResourceCollector) GetResourceTypes(
 	var crdResources []metav1.GroupVersionKind
 	var crdList *stork_api.ApplicationRegistrationList
 	storkcache.Instance()
-	if !reflect.ValueOf(storage.Instance()).IsNil() {
+	if !reflect.ValueOf(storkcache.Instance()).IsNil() {
 		crdList, err = storkcache.Instance().ListApplicationRegistrations()
 	} else {
 		crdList, err = r.storkOps.ListApplicationRegistrations()
@@ -256,6 +257,7 @@ func (r *ResourceCollector) GetResourceTypes(
 }
 
 // GetResourcesForType gets all the resources for the given type
+// and all PVCs which have an owner reference set.
 func (r *ResourceCollector) GetResourcesForType(
 	resource metav1.APIResource,
 	objects *Objects,
@@ -264,7 +266,7 @@ func (r *ResourceCollector) GetResourcesForType(
 	includeObjects map[stork_api.ObjectInfo]bool,
 	allDrivers bool,
 	opts Options,
-) (*Objects, error) {
+) (*Objects, []v1.PersistentVolumeClaim, error) {
 
 	if objects == nil {
 		objects = &Objects{
@@ -284,7 +286,7 @@ func (r *ResourceCollector) GetResourcesForType(
 	crbs, err := r.rbacOps.ListClusterRoleBindings()
 	if err != nil {
 		if !apierrors.IsForbidden(err) {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 	for _, ns := range namespaces {
@@ -306,40 +308,40 @@ func (r *ResourceCollector) GetResourcesForType(
 			LabelSelector: selectors,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("error listing objects for %v: %v", gvr, err)
+			return nil, nil, fmt.Errorf("error listing objects for %v: %v", gvr, err)
 		}
 		resourceObjects, err := meta.ExtractList(objectsList)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		for _, o := range resourceObjects {
 			runtimeObject, ok := o.(runtime.Unstructured)
 			if !ok {
-				return nil, fmt.Errorf("error casting object: %v", o)
+				return nil, nil, fmt.Errorf("error casting object: %v", o)
 			}
 
 			collect, err := r.objectToBeCollected(includeObjects, labelSelectors, objects.resourceMap, runtimeObject, ns, allDrivers, opts, crbs)
 			if err != nil {
-				return nil, fmt.Errorf("error processing object %v: %v", runtimeObject, err)
+				return nil, nil, fmt.Errorf("error processing object %v: %v", runtimeObject, err)
 			}
 			if !collect {
 				continue
 			}
 			metadata, err := meta.Accessor(runtimeObject)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			objects.Items = append(objects.Items, runtimeObject)
 			objects.resourceMap[metadata.GetUID()] = true
 		}
 	}
 
-	modObjects, err := r.pruneOwnedResources(objects.Items, objects.resourceMap)
+	modObjects, pvcObjectsWithOwnerRef, err := r.pruneOwnedResources(objects.Items, objects.resourceMap)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var crdList *stork_api.ApplicationRegistrationList
-	if !reflect.ValueOf(storage.Instance()).IsNil() {
+	if !reflect.ValueOf(storkcache.Instance()).IsNil() {
 		crdList, err = storkcache.Instance().ListApplicationRegistrations()
 	} else {
 		crdList, err = r.storkOps.ListApplicationRegistrations()
@@ -347,15 +349,29 @@ func (r *ResourceCollector) GetResourcesForType(
 	if err != nil {
 		logrus.Warnf("Unable to get registered crds, err %v", err)
 	}
+
+	// Creating a list of PVCs with owner reference before calling prepareResourcesForCollection
+	// prepareResourcesForCollection can update the PVC metadata which is required when updating
+	// owner references on the destination PVC objects
+	var pvcsWithOwnerReference []v1.PersistentVolumeClaim
+	var pvc v1.PersistentVolumeClaim
+	for _, o := range pvcObjectsWithOwnerRef {
+		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(o.UnstructuredContent(), &pvc); err != nil {
+			logrus.Warnf("unable to cast pvcs with owner reference: %v", err)
+		}
+		pvcsWithOwnerReference = append(pvcsWithOwnerReference, pvc)
+	}
+
 	err = r.prepareResourcesForCollection(modObjects, namespaces, opts, crdList)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	objects.Items = modObjects
-	return objects, nil
+	return objects, pvcsWithOwnerReference, nil
 }
 
 // GetResources gets all the resources in the given list of namespaces which match the labelSelectors
+// and all PVCs which have an owner reference set
 func (r *ResourceCollector) GetResources(
 	namespaces []string,
 	labelSelectors map[string]string,
@@ -363,17 +379,17 @@ func (r *ResourceCollector) GetResources(
 	optionalResourceTypes []string,
 	allDrivers bool,
 	opts Options,
-) ([]runtime.Unstructured, error) {
+) ([]runtime.Unstructured, []v1.PersistentVolumeClaim, error) {
 	err := r.discoveryHelper.Refresh()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	allObjects := make([]runtime.Unstructured, 0)
 	// Map to prevent collection of duplicate objects
 	resourceMap := make(map[types.UID]bool)
 	var crdResources []metav1.GroupVersionKind
 	var crdList *stork_api.ApplicationRegistrationList
-	if !reflect.ValueOf(storage.Instance()).IsNil() {
+	if !reflect.ValueOf(storkcache.Instance()).IsNil() {
 		crdList, err = storkcache.Instance().ListApplicationRegistrations()
 	} else {
 		crdList, err = r.storkOps.ListApplicationRegistrations()
@@ -393,14 +409,14 @@ func (r *ResourceCollector) GetResources(
 	crbs, err := r.rbacOps.ListClusterRoleBindings()
 	if err != nil {
 		if !apierrors.IsForbidden(err) {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	for _, group := range r.discoveryHelper.Resources() {
 		groupVersion, err := schema.ParseGroupVersion(group.GroupVersion)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		for _, resource := range group.APIResources {
@@ -436,16 +452,16 @@ func (r *ResourceCollector) GetResources(
 					if apierrors.IsForbidden(err) {
 						continue
 					}
-					return nil, err
+					return nil, nil, err
 				}
 				objects, err := meta.ExtractList(objectsList)
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 				for _, o := range objects {
 					runtimeObject, ok := o.(runtime.Unstructured)
 					if !ok {
-						return nil, fmt.Errorf("error casting object: %v", o)
+						return nil, nil, fmt.Errorf("error casting object: %v", o)
 					}
 
 					var err error
@@ -462,14 +478,14 @@ func (r *ResourceCollector) GetResources(
 						if apierrors.IsForbidden(err) {
 							continue
 						}
-						return nil, fmt.Errorf("error processing object %v: %v", runtimeObject, err)
+						return nil, nil, fmt.Errorf("error processing object %v: %v", runtimeObject, err)
 					}
 					if !collect {
 						continue
 					}
 					metadata, err := meta.Accessor(runtimeObject)
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 					allObjects = append(allObjects, runtimeObject)
 					resourceMap[metadata.GetUID()] = true
@@ -478,16 +494,29 @@ func (r *ResourceCollector) GetResources(
 		}
 	}
 
-	allObjects, err = r.pruneOwnedResources(allObjects, resourceMap)
+	allObjects, pvcObjectsWithOwnerRef, err := r.pruneOwnedResources(allObjects, resourceMap)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+
+	// Creating a list of PVCs with owner reference before calling prepareResourcesForCollection
+	// prepareResourcesForCollection can update the PVC metadata which is required when updating
+	// owner references on the destination PVC objects
+	var pvcsWithOwnerReference []v1.PersistentVolumeClaim
+	var pvc v1.PersistentVolumeClaim
+	for _, o := range pvcObjectsWithOwnerRef {
+		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(o.UnstructuredContent(), &pvc); err != nil {
+			logrus.Warnf("unable to cast pvcs with owner reference: %v", err)
+		}
+		pvcsWithOwnerReference = append(pvcsWithOwnerReference, pvc)
 	}
 
 	err = r.prepareResourcesForCollection(allObjects, namespaces, opts, crdList)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return allObjects, nil
+
+	return allObjects, pvcsWithOwnerReference, nil
 }
 
 // IsNsPresentInIncludeResource checks if a given ns is present in the IncludeResource object
@@ -613,30 +642,41 @@ func (r *ResourceCollector) objectToBeCollected(
 // Prune objects that are owned by a CRD if we are also collecting the CR
 // since they will be recreated by the operator when the CR is created too.
 // For objects that have an ownerRef but we aren't collecting it's owner
-// remove the ownerRef so that the object doesn't get automatically deleted
-// when created
+// remove the ownerRef so that the object doesn't get automatically deleted.
+// Collect PVCs with owner reference separately as we do need to set owner
+// references for them after migrating parent CR
 func (r *ResourceCollector) pruneOwnedResources(
 	objects []runtime.Unstructured,
 	resourceMap map[types.UID]bool,
-) ([]runtime.Unstructured, error) {
+) ([]runtime.Unstructured, []runtime.Unstructured, error) {
 	updatedObjects := make([]runtime.Unstructured, 0)
+	pvcObjectsWithOwnerRef := make([]runtime.Unstructured, 0)
+
 	for _, o := range objects {
 		metadata, err := meta.Accessor(o)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		collect := true
 
 		objectType, err := meta.TypeAccessor(o)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		// Don't check for PVCs, we always want to collect them
-		if objectType.GetKind() != "PersistentVolumeClaim" {
-			owners := metadata.GetOwnerReferences()
-			if len(owners) != 0 {
+		owners := metadata.GetOwnerReferences()
+		if len(owners) != 0 {
+			if objectType.GetKind() == "PersistentVolumeClaim" {
+				for _, owner := range owners {
+					// Collect PVC objects separately. If OwnerReferences is available
+					// but the corresponding resource is not being collected, then
+					// no need to collect resource and we will not manually patch those PVCs
+					if _, exists := resourceMap[owner.UID]; exists {
+						pvcObjectsWithOwnerRef = append(pvcObjectsWithOwnerRef, o)
+						break
+					}
+				}
+			} else {
 				if !skipOwnerRefCheck(metadata.GetAnnotations()) {
 					for _, owner := range owners {
 						// We don't collect pods, there might be some leader
@@ -646,7 +686,11 @@ func (r *ResourceCollector) pruneOwnedResources(
 							collect = false
 							break
 						}
-						if objectType.GetKind() != "Deployment" && objectType.GetKind() != "StatefulSet" && objectType.GetKind() != "ReplicaSet" && objectType.GetKind() != "DeploymentConfig" {
+						if objectType.GetKind() != "Deployment" &&
+							objectType.GetKind() != "StatefulSet" &&
+							objectType.GetKind() != "ReplicaSet" &&
+							objectType.GetKind() != "DeploymentConfig" &&
+							objectType.GetKind() != "Service" {
 							continue
 						}
 
@@ -666,7 +710,7 @@ func (r *ResourceCollector) pruneOwnedResources(
 		}
 	}
 
-	return updatedObjects, nil
+	return updatedObjects, pvcObjectsWithOwnerRef, nil
 
 }
 

--- a/vendor/github.com/libopenstorage/stork/pkg/utils/utils.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/utils/utils.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/aquilax/truncate"
 	"github.com/libopenstorage/stork/drivers"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
@@ -9,8 +11,8 @@ import (
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"strings"
 )
 
 const (
@@ -165,4 +167,14 @@ func IsNFSBackuplocationType(
 		return true, nil
 	}
 	return false, nil
+}
+
+func GetUIDLastSection(uid types.UID) string {
+	parts := strings.Split(string(uid), "-")
+	uidLastSection := parts[len(parts)-1]
+
+	if uidLastSection == "" {
+		uidLastSection = string(uid)
+	}
+	return uidLastSection
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -384,7 +384,7 @@ github.com/libopenstorage/openstorage-sdk-clients/sdk/golang
 github.com/libopenstorage/secrets
 github.com/libopenstorage/secrets/aws/credentials
 github.com/libopenstorage/secrets/k8s
-# github.com/libopenstorage/stork v1.4.1-0.20230208122050-965b4be91e93
+# github.com/libopenstorage/stork v1.4.1-0.20230216111318-15ed8c1a7d43
 ## explicit; go 1.19
 github.com/libopenstorage/stork/drivers
 github.com/libopenstorage/stork/drivers/volume


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-3447: Added uploadCSISnapshots to upload the snapshot.json as part of nfs executor job.
```
**Which issue(s) this PR fixes** (optional)
Closes #pb-3447

**Special notes for your reviewer**:
Testing:
snapshot.json from minio backuplocation:
```
{"volumeSnapshots":{"backup-aaa715bf6405-9f7465534d49":{"metadata":{"name":"backup-aaa715bf6405-9f7465534d49","namespace":"mysql-pso","uid":"4a7e8cee-7e30-4e3e-8c93-6bb5e130b84e","resourceVersion":"401015","generation":1,"creationTimestamp":"2023-01-29T07:14:41Z","finalizers":["snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection"],"managedFields":[{"manager":"stork","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-29T07:14:41Z","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{".":{},"f:source":{".":{},"f:persistentVolumeClaimName":{}},"f:volumeSnapshotClassName":{}}}},{"manager":"snapshot-controller","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-29T07:14:42Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:finalizers":{}},"f:status":{".":{},"f:boundVolumeSnapshotContentName":{},"f:creationTime":{},"f:readyToUse":{},"f:restoreSize":{}}}}]},"spec":{"source":{"persistentVolumeClaimName":"mysql-data"},"volumeSnapshotClassName":"stork-csi-snapshot-class-pure-csi"},"status":{"boundVolumeSnapshotContentName":"snapcontent-4a7e8cee-7e30-4e3e-8c93-6bb5e130b84e","creationTime":"2023-01-29T07:14:42Z","readyToUse":true,"restoreSize":"0"}}},"volumeSnapshotContents":{"backup-aaa715bf6405-9f7465534d49":{"metadata":{"name":"snapcontent-4a7e8cee-7e30-4e3e-8c93-6bb5e130b84e","uid":"3ae786e2-1357-4675-8413-2aa7de12a0b6","resourceVersion":"401013","generation":1,"creationTimestamp":"2023-01-29T07:14:41Z","finalizers":["snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection"],"managedFields":[{"manager":"snapshot-controller","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-29T07:14:41Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:finalizers":{".":{},"v:\"snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection\"":{}}},"f:spec":{".":{},"f:deletionPolicy":{},"f:driver":{},"f:source":{".":{},"f:volumeHandle":{}},"f:volumeSnapshotClassName":{},"f:volumeSnapshotRef":{".":{},"f:apiVersion":{},"f:kind":{},"f:name":{},"f:namespace":{},"f:resourceVersion":{},"f:uid":{}}}}},{"manager":"csi-snapshotter","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1beta1","time":"2023-01-29T07:14:42Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{".":{},"f:creationTime":{},"f:readyToUse":{},"f:restoreSize":{},"f:snapshotHandle":{}}}}]},"spec":{"volumeSnapshotRef":{"kind":"VolumeSnapshot","namespace":"mysql-pso","name":"backup-aaa715bf6405-9f7465534d49","uid":"4a7e8cee-7e30-4e3e-8c93-6bb5e130b84e","apiVersion":"snapshot.storage.k8s.io/v1","resourceVersion":"400994"},"deletionPolicy":"Retain","driver":"pure-csi","volumeSnapshotClassName":"stork-csi-snapshot-class-pure-csi","source":{"volumeHandle":"f691d82f-ca80-43bd-87c0-e2c1514605a8"}},"status":{"snapshotHandle":"PSO_siva_pso-pvc-720797b5-838b-4eb4-81a7-9f7465534d49.snapshot-4a7e8cee-7e30-4e3e-8c93-6bb5e130b84e","creationTime":1674976482000000000,"restoreSize":0,"readyToUse":true}}},"volumeSnapshotClasses":{"stork-csi-snapshot-class-pure-csi":{"metadata":{"name":"stork-csi-snapshot-class-pure-csi","uid":"82492a91-3225-4d2b-8449-0e2fcb4208f1","resourceVersion":"27020","generation":1,"creationTimestamp":"2023-01-28T12:00:06Z","managedFields":[{"manager":"stork","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-28T12:00:06Z","fieldsType":"FieldsV1","fieldsV1":{"f:deletionPolicy":{},"f:driver":{}}}]},"driver":"pure-csi","deletionPolicy":"Retain"}},"V1VolumeSnapshotRequired":true}
```
snapshot.json from nfs backuplocaiton:
```
[root@ssubramani-setup1-0 3e121b6f-e582-49a6-809d-d963694bd54c]# ls
crds.json  metadata.json  namespaces.json  resources.json  snapshots.json  storageclass.json
[root@ssubramani-setup1-0 3e121b6f-e582-49a6-809d-d963694bd54c]# cat snapshots.json
{"volumeSnapshots":{"backup-d963694bd54c-9f7465534d49":{"metadata":{"name":"backup-d963694bd54c-9f7465534d49","namespace":"mysql-pso","uid":"025d08f9-2c57-449b-a608-8defee43a9b0","resourceVersion":"405700","generation":1,"creationTimestamp":"2023-01-29T07:28:41Z","finalizers":["snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection"],"managedFields":[{"manager":"stork","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-29T07:28:41Z","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{".":{},"f:source":{".":{},"f:persistentVolumeClaimName":{}},"f:volumeSnapshotClassName":{}}}},{"manager":"snapshot-controller","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-29T07:28:42Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:finalizers":{}},"f:status":{".":{},"f:boundVolumeSnapshotContentName":{},"f:creationTime":{},"f:readyToUse":{},"f:restoreSize":{}}}}]},"spec":{"source":{"persistentVolumeClaimName":"mysql-data"},"volumeSnapshotClassName":"stork-csi-snapshot-class-pure-csi"},"status":{"boundVolumeSnapshotContentName":"snapcontent-025d08f9-2c57-449b-a608-8defee43a9b0","creationTime":"2023-01-29T07:28:41Z","readyToUse":true,"restoreSize":"0"}}},"volumeSnapshotContents":{"backup-d963694bd54c-9f7465534d49":{"metadata":{"name":"snapcontent-025d08f9-2c57-449b-a608-8defee43a9b0","uid":"196039c8-6e43-4378-b6a7-d075281424d6","resourceVersion":"405697","generation":1,"creationTimestamp":"2023-01-29T07:28:41Z","finalizers":["snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection"],"managedFields":[{"manager":"csi-snapshotter","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1beta1","time":"2023-01-29T07:28:41Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{".":{},"f:creationTime":{},"f:readyToUse":{},"f:restoreSize":{},"f:snapshotHandle":{}}}},{"manager":"snapshot-controller","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-29T07:28:41Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:finalizers":{".":{},"v:\"snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection\"":{}}},"f:spec":{".":{},"f:deletionPolicy":{},"f:driver":{},"f:source":{".":{},"f:volumeHandle":{}},"f:volumeSnapshotClassName":{},"f:volumeSnapshotRef":{".":{},"f:apiVersion":{},"f:kind":{},"f:name":{},"f:namespace":{},"f:resourceVersion":{},"f:uid":{}}}}}]},"spec":{"volumeSnapshotRef":{"kind":"VolumeSnapshot","namespace":"mysql-pso","name":"backup-d963694bd54c-9f7465534d49","uid":"025d08f9-2c57-449b-a608-8defee43a9b0","apiVersion":"snapshot.storage.k8s.io/v1","resourceVersion":"405683"},"deletionPolicy":"Retain","driver":"pure-csi","volumeSnapshotClassName":"stork-csi-snapshot-class-pure-csi","source":{"volumeHandle":"f691d82f-ca80-43bd-87c0-e2c1514605a8"}},"status":{"snapshotHandle":"PSO_siva_pso-pvc-720797b5-838b-4eb4-81a7-9f7465534d49.snapshot-025d08f9-2c57-449b-a608-8defee43a9b0","creationTime":1674977321000000000,"restoreSize":0,"readyToUse":true}}},"volumeSnapshotClasses":{"stork-csi-snapshot-class-pure-csi":{"metadata":{"name":"stork-csi-snapshot-class-pure-csi","uid":"82492a91-3225-4d2b-8449-0e2fcb4208f1","resourceVersion":"27020","generation":1,"creationTimestamp":"2023-01-28T12:00:06Z","managedFields":[{"manager":"stork","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-28T12:00:06Z","fieldsType":"FieldsV1","fieldsV1":{"f:deletionPolicy":{},"f:driver":{}}}]},"driver":"pure-csi","deletionPolicy":"Retain"}},"V1VolumeSnapshotRequired":true}[root@ssubramani-setup1-0 3e121b6f-e582-49a6-809d-d963694bd54c]#
```