### PR TITLE
pb-3637: Added S3 region option to the kopia command

### DIFF
--- a/pkg/executor/kopia/kopiabackup.go
+++ b/pkg/executor/kopia/kopiabackup.go
@@ -215,6 +215,7 @@ func runKopiaCreateRepo(repository *executor.Repository) error {
 			repository.Name,
 			repository.Password,
 			kopiaProviderType[repository.Type],
+			repository.S3Config.Region,
 			repository.S3Config.DisableSSL,
 		)
 	default:
@@ -223,6 +224,7 @@ func runKopiaCreateRepo(repository *executor.Repository) error {
 			repository.Name,
 			repository.Password,
 			kopiaProviderType[repository.Type],
+			"",
 			false,
 		)
 	}
@@ -350,6 +352,7 @@ func runKopiaRepositoryConnect(repository *executor.Repository) error {
 			repository.Name,
 			repository.Password,
 			kopiaProviderType[repository.Type],
+			repository.S3Config.Region,
 			repository.S3Config.DisableSSL,
 		)
 	default:
@@ -357,6 +360,7 @@ func runKopiaRepositoryConnect(repository *executor.Repository) error {
 			repository.Path,
 			repository.Name,
 			repository.Password,
+			"",
 			kopiaProviderType[repository.Type],
 			false,
 		)

--- a/pkg/kopia/command.go
+++ b/pkg/kopia/command.go
@@ -46,6 +46,8 @@ type Command struct {
 	DisableSsl bool
 	// Compression to be used for backup
 	Compression string
+	// Region for S3 object
+	Region string
 }
 
 // Executor interface defines APIs for implementing a command wrapper
@@ -116,6 +118,8 @@ func (c *Command) CreateCmd() *exec.Cmd {
 			logDir,
 			"--config-file",
 			configFile,
+			"--region",
+			c.Region,
 		}
 
 		if c.DisableSsl {
@@ -233,6 +237,8 @@ func (c *Command) ConnectCmd() *exec.Cmd {
 			logDir,
 			"--config-file",
 			configFile,
+			"--region",
+			c.Region,
 		}
 		if c.DisableSsl {
 			ssl := []string{

--- a/pkg/kopia/connect.go
+++ b/pkg/kopia/connect.go
@@ -30,7 +30,7 @@ const (
 )
 
 // GetConnectCommand returns a wrapper over the kopia connect command
-func GetConnectCommand(path, repoName, password, provider string, disableSsl bool) (*Command, error) {
+func GetConnectCommand(path, repoName, password, provider, region string, disableSsl bool) (*Command, error) {
 	if repoName == "" {
 		return nil, fmt.Errorf("repository name cannot be empty")
 	}
@@ -41,6 +41,7 @@ func GetConnectCommand(path, repoName, password, provider string, disableSsl boo
 		Password:       password,
 		Path:           path,
 		DisableSsl:     disableSsl,
+		Region:         region,
 	}, nil
 }
 

--- a/pkg/kopia/create.go
+++ b/pkg/kopia/create.go
@@ -35,7 +35,7 @@ type createExecutor struct {
 }
 
 // GetCreateCommand returns a wrapper over the kopia repo create command
-func GetCreateCommand(path, repoName, password, provider string, disableSsl bool) (*Command, error) {
+func GetCreateCommand(path, repoName, password, provider, region string, disableSsl bool) (*Command, error) {
 	if repoName == "" {
 		return nil, fmt.Errorf("repository name cannot be empty")
 	}
@@ -46,6 +46,7 @@ func GetCreateCommand(path, repoName, password, provider string, disableSsl bool
 		Password:       password,
 		Path:           path,
 		DisableSsl:     disableSsl,
+		Region:         region,
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-3637: Added S3 region option to the kopia command
```
**Which issue(s) this PR fixes** (optional)
Closes #pb-3637

**Special notes for your reviewer**:
Tested with the Oracle S3 objectstore with different region value.
