### PR TITLE
pb-3633: Added v1/v1beta version check in calling volumesnapshot class get in getSnapshotDriverName()

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -747,7 +747,15 @@ func (c *Controller) getSnapshotDriverName(dataExport *kdmpapi.DataExport) (stri
 	if err != nil {
 		return "", err
 	}
-	_, err = cs.SnapshotV1beta1().VolumeSnapshotClasses().Get(context.TODO(), dataExport.Spec.SnapshotStorageClass, metav1.GetOptions{})
+	v1SnapshotRequired, err := version.RequiresV1VolumeSnapshot()
+	if err != nil {
+		return "", err
+	}
+	if v1SnapshotRequired {
+		_, err = cs.SnapshotV1().VolumeSnapshotClasses().Get(context.TODO(), dataExport.Spec.SnapshotStorageClass, metav1.GetOptions{})
+	} else {
+		_, err = cs.SnapshotV1beta1().VolumeSnapshotClasses().Get(context.TODO(), dataExport.Spec.SnapshotStorageClass, metav1.GetOptions{})
+	}
 	if err == nil {
 		return csiProvider, nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-3633: Added v1/v1beta version check in calling volumesnapshot class get in getSnapshotDriverName()
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3633

**Special notes for your reviewer**:
Tested on the QA setup, Now we are not seeing the deprecated message.
