### PR TITLE
pb-3733: fixed the issue in pass region parameter in connect cmd for …

### DIFF
--- a/pkg/executor/kopia/kopiabackup.go
+++ b/pkg/executor/kopia/kopiabackup.go
@@ -342,8 +342,8 @@ func runKopiaRepositoryConnect(repository *executor.Repository) error {
 			repository.Path,
 			repository.Name,
 			repository.Password,
-			"",
 			kopiaProvderType[repository.Type],
+			"",
 			false,
 		)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
```
    pb-3733: fixed the issue in pass region parameter in connect cmd for non aws cases.

    Signed-off-by: Sivakumar Subramani <ssubramani@purestorage.com>
```
**Which issue(s) this PR fixes** (optional)
Closes #pb-3733

**Special notes for your reviewer**:
Testing kdmp backup on QA setup on Azure cluster.
