### PR TITLE
pb-3829: Added check in the job pods to fail, when mount failure is hit.

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -1158,7 +1158,7 @@ func (c *Controller) stageLocalSnapshotRestore(ctx context.Context, dataExport *
 			dataExport,
 			bl,
 		)
-		logrus.Tracef("started nfs csi restore job for dataexport id: %v", id, dataExport.Name)
+		logrus.Tracef("started nfs csi restore job for dataexport id: %v, name: %v", id, dataExport.Name)
 		if err != nil {
 			logrus.Errorf("nfs csi restore job failed err: %v", err)
 			msg := fmt.Sprintf("Restoring from local snapshot with nfs csi restore job failed for for volumebackup %s in namespace %s: %v",

--- a/pkg/controllers/resourceexport/reconcile.go
+++ b/pkg/controllers/resourceexport/reconcile.go
@@ -157,7 +157,7 @@ func (c *Controller) process(ctx context.Context, in *kdmpapi.ResourceExport) (b
 			updateData := updateResourceExportFields{
 				stage:  kdmpapi.ResourceExportStageFinal,
 				status: kdmpapi.ResourceExportStatusFailed,
-				reason: fmt.Sprintf("failed to create ResourceBackup CR [%v/%v]", resourceExport.Namespace, resourceExport.Name),
+				reason: progress.Reason,
 			}
 			if len(progress.Reason) == 0 {
 				// As we couldn't get actual reason from executor

--- a/pkg/drivers/nfsbackup/nfsbackup.go
+++ b/pkg/drivers/nfsbackup/nfsbackup.go
@@ -82,6 +82,14 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
+
+	// Check whether mount point failure
+	mountFailed := utils.IsJobPodMountFailed(job, namespace)
+	if mountFailed {
+		errMsg := fmt.Sprintf("job [%v/%v] failed while mounting NFS mount endpoint", namespace, name)
+		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
+	}
+
 	var jobStatus batchv1.JobConditionType
 	if len(job.Status.Conditions) != 0 {
 		jobStatus = job.Status.Conditions[0].Type

--- a/pkg/drivers/nfscsirestore/nfscsirestore.go
+++ b/pkg/drivers/nfscsirestore/nfscsirestore.go
@@ -79,6 +79,12 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
+	// Check for mount point failure
+	mountFailed := utils.IsJobPodMountFailed(job, namespace)
+	if mountFailed {
+		errMsg := fmt.Sprintf("job [%v/%v] failed while mounting NFS mount endpoint", namespace, name)
+		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
+	}
 	var jobStatus batchv1.JobConditionType
 	if len(job.Status.Conditions) != 0 {
 		jobStatus = job.Status.Conditions[0].Type

--- a/pkg/drivers/nfsdelete/nfsdelete.go
+++ b/pkg/drivers/nfsdelete/nfsdelete.go
@@ -106,6 +106,12 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
+	// Check for mount point failure
+	mountFailed := utils.IsJobPodMountFailed(job, namespace)
+	if mountFailed {
+		errMsg := fmt.Sprintf("job [%v/%v] failed while mounting NFS mount endpoint", namespace, name)
+		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
+	}
 	err = utils.JobNodeExists(job)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to fetch the node info tied to the job %s/%s: %v", namespace, name, err)

--- a/pkg/drivers/nfsrestore/nfsrestore.go
+++ b/pkg/drivers/nfsrestore/nfsrestore.go
@@ -83,6 +83,12 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
+	// Check for mount point failure
+	mountFailed := utils.IsJobPodMountFailed(job, namespace)
+	if mountFailed {
+		errMsg := fmt.Sprintf("job [%v/%v] failed while mounting NFS mount endpoint", namespace, name)
+		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
+	}
 	var jobStatus batchv1.JobConditionType
 	if len(job.Status.Conditions) != 0 {
 		jobStatus = job.Status.Conditions[0].Type


### PR DESCRIPTION
**What this PR does / why we need it**:
```
   pb-3829: Added check in the job pods to fail, when mount failure is hit.

            - Add the check in nfsbackup, nfsrestore, nfsdelete,
              nfscsirestore job
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3829

**Special notes for your reviewer**:
Tested for backup with invalid nfs backuplocation.

![Screenshot 2023-05-11 at 4 29 52 PM](https://github.com/portworx/kdmp/assets/52188641/4dcc7e9e-cd0e-492d-9d5f-2dbc50572d4e)
