### PR TITLE
pb-3855: Adding the imageregistry secret to kdmp jobs, only if it is present in the source deployment spec ( stork or px-backup).

### DIFF
--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -227,7 +227,6 @@ func jobFor(
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					ServiceAccountName: jobOption.ServiceAccountName,
-					ImagePullSecrets:   utils.ToImagePullSecret(imageRegistrySecret),
 					Containers: []corev1.Container{
 						{
 							Name:  "kopiaexecutor",
@@ -264,6 +263,10 @@ func jobFor(
 				},
 			},
 		},
+	}
+	// Add the image secret in job spec only if it is present in the stork deployment.
+	if len(imageRegistrySecret) != 0 {
+		job.Spec.Template.Spec.ImagePullSecrets = utils.ToImagePullSecret(utils.GetImageSecretName(jobName))
 	}
 
 	if len(jobOption.NfsServer) != 0 {

--- a/pkg/drivers/kopiamaintenance/kopiamaintenance.go
+++ b/pkg/drivers/kopiamaintenance/kopiamaintenance.go
@@ -234,7 +234,6 @@ func jobFor(
 	jobSpec := corev1.PodSpec{
 		RestartPolicy:      corev1.RestartPolicyOnFailure,
 		ServiceAccountName: jobOption.ServiceAccountName,
-		ImagePullSecrets:   utils.ToImagePullSecret(imageRegistrySecret),
 		Containers: []corev1.Container{
 			{
 				Name:  "kopiaexecutor",
@@ -268,6 +267,10 @@ func jobFor(
 				},
 			},
 		},
+	}
+	// Add the image secret in job spec only if it is present in the stork deployment.
+	if len(imageRegistrySecret) != 0 {
+		jobSpec.ImagePullSecrets = utils.ToImagePullSecret(utils.GetImageSecretName(jobName))
 	}
 	var volumeMount corev1.VolumeMount
 	var volume corev1.Volume

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -200,7 +200,7 @@ func jobFor(
 		vb.Status.SnapshotID,
 	}, " ")
 
-	kopiaExecutorImage, _, err := utils.GetExecutorImageAndSecret(drivers.KopiaExecutorImage,
+	kopiaExecutorImage, imageRegistrySecret, err := utils.GetExecutorImageAndSecret(drivers.KopiaExecutorImage,
 		jobOption.KopiaImageExecutorSource,
 		jobOption.KopiaImageExecutorSourceNs,
 		jobName,
@@ -233,7 +233,6 @@ func jobFor(
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ImagePullSecrets:   utils.ToImagePullSecret(utils.GetImageSecretName(jobName)),
 					ServiceAccountName: jobName,
 					Containers: []corev1.Container{
 						{
@@ -282,6 +281,11 @@ func jobFor(
 				},
 			},
 		},
+	}
+
+	// Add the image secret in job spec only if it is present in the stork deployment.
+	if len(imageRegistrySecret) != 0 {
+		job.Spec.Template.Spec.ImagePullSecrets = utils.ToImagePullSecret(utils.GetImageSecretName(jobName))
 	}
 
 	if drivers.CertFilePath != "" {

--- a/pkg/drivers/nfscsirestore/nfscsirestore.go
+++ b/pkg/drivers/nfscsirestore/nfscsirestore.go
@@ -192,7 +192,7 @@ func jobForRestoreCSISnapshot(
 
 	labels := addJobLabels(jobOption.Labels)
 
-	nfsExecutorImage, _, err := utils.GetExecutorImageAndSecret(drivers.NfsExecutorImage,
+	nfsExecutorImage, imageRegistrySecret, err := utils.GetExecutorImageAndSecret(drivers.NfsExecutorImage,
 		jobOption.NfsImageExecutorSource,
 		jobOption.NfsImageExecutorSourceNs,
 		jobOption.DataExportName,
@@ -224,7 +224,6 @@ func jobForRestoreCSISnapshot(
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ImagePullSecrets:   utils.ToImagePullSecret(utils.GetImageSecretName(jobOption.DataExportName)),
 					ServiceAccountName: jobOption.DataExportName,
 					Containers: []corev1.Container{
 						{
@@ -261,6 +260,10 @@ func jobForRestoreCSISnapshot(
 				},
 			},
 		},
+	}
+	// Add the image secret in job spec only if it is present in the stork deployment.
+	if len(imageRegistrySecret) != 0 {
+		job.Spec.Template.Spec.ImagePullSecrets = utils.ToImagePullSecret(utils.GetImageSecretName(jobOption.DataExportName))
 	}
 	if len(jobOption.NfsServer) != 0 {
 		volumeMount := corev1.VolumeMount{

--- a/pkg/drivers/nfsdelete/nfsdelete.go
+++ b/pkg/drivers/nfsdelete/nfsdelete.go
@@ -170,7 +170,7 @@ func jobForDeleteResource(
 		jobOption.AppCRNamespace,
 	}, " ")
 
-	nfsExecutorImage, _, err := utils.GetExecutorImageAndSecret(drivers.NfsExecutorImage,
+	nfsExecutorImage, imageRegistrySecret, err := utils.GetExecutorImageAndSecret(drivers.NfsExecutorImage,
 		jobOption.NfsImageExecutorSource,
 		jobOption.NfsImageExecutorSourceNs,
 		jobOption.JobName,
@@ -202,7 +202,6 @@ func jobForDeleteResource(
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ImagePullSecrets:   utils.ToImagePullSecret(utils.GetImageSecretName(jobOption.JobName)),
 					ServiceAccountName: jobOption.ServiceAccountName,
 					Containers: []corev1.Container{
 						{
@@ -239,6 +238,10 @@ func jobForDeleteResource(
 				},
 			},
 		},
+	}
+	// Add the image secret in job spec only if it is present in the stork deployment.
+	if len(imageRegistrySecret) != 0 {
+		job.Spec.Template.Spec.ImagePullSecrets = utils.ToImagePullSecret(utils.GetImageSecretName(jobOption.JobName))
 	}
 	if len(jobOption.NfsServer) != 0 {
 		volumeMount := corev1.VolumeMount{

--- a/pkg/drivers/nfsrestore/nfsrestore.go
+++ b/pkg/drivers/nfsrestore/nfsrestore.go
@@ -215,7 +215,7 @@ func jobForRestoreResource(
 
 	labels := addJobLabels(jobOption.Labels)
 
-	nfsExecutorImage, _, err := utils.GetExecutorImageAndSecret(drivers.NfsExecutorImage,
+	nfsExecutorImage, imageRegistrySecret, err := utils.GetExecutorImageAndSecret(drivers.NfsExecutorImage,
 		jobOption.NfsImageExecutorSource,
 		jobOption.NfsImageExecutorSourceNs,
 		jobOption.RestoreExportName,
@@ -260,7 +260,6 @@ func jobForRestoreResource(
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ImagePullSecrets:   utils.ToImagePullSecret(utils.GetImageSecretName(jobOption.RestoreExportName)),
 					ServiceAccountName: jobOption.RestoreExportName,
 					Containers: []corev1.Container{
 						{
@@ -307,6 +306,10 @@ func jobForRestoreResource(
 				},
 			},
 		},
+	}
+	// Add the image secret in job spec only if it is present in the stork deployment.
+	if len(imageRegistrySecret) != 0 {
+		job.Spec.Template.Spec.ImagePullSecrets = utils.ToImagePullSecret(utils.GetImageSecretName(jobOption.RestoreExportName))
 	}
 	if len(jobOption.NfsServer) != 0 {
 		volumeMount := corev1.VolumeMount{


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-3855: Adding the imageregistry secret to kdmp jobs, only if it is present in the source deployment spec ( stork or px-backup).
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3855

**Special notes for your reviewer**:
Testing:
Planning to ask QA to test the kdmp backup and restore with imageregistry secret setup.

