### PR TITLE
pb-3891: fixed issues in restore pvcs from multiple driver from backup.

### DIFF
--- a/pkg/executor/common.go
+++ b/pkg/executor/common.go
@@ -502,12 +502,13 @@ func UpdateStatusInResourceBackup(
 ) (*kdmpapi.ResourceBackup, error) {
 	var rb *kdmpapi.ResourceBackup
 	var err error
+	var errMsg string
 	for i := 0; i < maxRetry; i++ {
 		rb, err = kdmpschedops.Instance().GetResourceBackup(rbName, rbNamespace)
 		if err != nil {
-			errMsg := fmt.Sprintf("error reading ResourceBackup CR[%v/%v]: %v", rbNamespace, rbName, err)
+			errMsg = fmt.Sprintf("error reading ResourceBackup CR[%v/%v]: %v", rbNamespace, rbName, err)
 			time.Sleep(retrySleep)
-			return nil, fmt.Errorf(errMsg)
+			continue
 		}
 		if !newRbStatus.LargeResourceEnabled {
 			rb.Status.LargeResourceEnabled = newRbStatus.LargeResourceEnabled
@@ -532,12 +533,15 @@ func UpdateStatusInResourceBackup(
 		}
 		rb, err = kdmpschedops.Instance().UpdateResourceBackup(rb)
 		if err != nil {
-			errMsg := fmt.Sprintf("error updating ResourceBackup CR[%v/%v]: %v", rbNamespace, rbName, err)
+			errMsg = fmt.Sprintf("error updating ResourceBackup CR[%v/%v]: %v", rbNamespace, rbName, err)
 			time.Sleep(retrySleep)
-			return nil, fmt.Errorf(errMsg)
+		} else {
+			break
 		}
 	}
-
+	if err != nil {
+		return nil, fmt.Errorf(errMsg)
+	}
 	return rb, nil
 }
 

--- a/pkg/executor/nfs/nfsrestorevolcreate.go
+++ b/pkg/executor/nfs/nfsrestorevolcreate.go
@@ -179,7 +179,7 @@ func restoreVolResourcesAndApply(
 		backupVolInfos := bkpvInfo
 		// Skip pv/pvc if replacepolicy is set to retain to avoid creating
 		if restore.Spec.ReplacePolicy == storkapi.ApplicationRestoreReplacePolicyRetain {
-			backupVolInfos, existingRestoreVolInfos, err = skipVolumesFromRestoreList(restore, objects, driver, backup.Status.Volumes)
+			backupVolInfos, existingRestoreVolInfos, err = skipVolumesFromRestoreList(restore, objects, driver, backupVolInfos)
 			if err != nil {
 				log.ApplicationRestoreLog(restore).Errorf("Error while checking pvcs: %v", err)
 				return err
@@ -314,9 +314,9 @@ func restoreVolResourcesAndApply(
 					}
 					return nil
 				}
-				message := fmt.Sprintf("Error starting Application Restore for volumes: %v", err)
+				message := fmt.Sprintf("Error starting Application Restore for volumes: %v", sErr)
 				log.ApplicationRestoreLog(restore).Errorf(message)
-				return err
+				return sErr
 			}
 			time.Sleep(volumeBatchSleepInterval)
 			restoreCompleteList = append(restoreCompleteList, restoreVolumeInfos...)


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-3891: fixed issues in restore pvcs from multiple driver from backup.

            - fixed the issue in returning error from nfsrestorevolcreate job
            - corrected the volume list passed to skipVolumesFromRestoreList
            - Fixed the issue in retry logic of UpdateStatusInResourceBackup
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3891

**Special notes for your reviewer**:
Tested on QA setup:

![Screenshot 2023-05-23 at 2 18 14 AM](https://github.com/portworx/kdmp/assets/52188641/7c7974c9-e9b8-4670-9407-3b2ba7f11fd8)
![Screenshot 2023-05-23 at 2 17 57 AM](https://github.com/portworx/kdmp/assets/52188641/b2c96b06-7624-473a-bc31-a27c3e916374)
![Screenshot 2023-05-23 at 12 01 57 AM](https://github.com/portworx/kdmp/assets/52188641/098d8a4c-73a8-4c3c-96c0-6309e1aaa789)
