### PR TITLE
pb-3907: passing backuplocation CR details to resourceCollector.PrepareResourceForApply

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7
-	github.com/libopenstorage/stork v1.4.1-0.20230519043154-cbc10dffaf19
+	github.com/libopenstorage/stork v1.4.1-0.20230601053837-5dd68f026569
 	github.com/portworx/pxc v0.33.0
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20230331045738-90076ccca1b6
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20230426231724-8d9f2c104721
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1784,8 +1784,8 @@ github.com/libopenstorage/stork v1.4.1-0.20220323180113-0ea773109d05/go.mod h1:h
 github.com/libopenstorage/stork v1.4.1-0.20220414104250-3c18fd21ed95/go.mod h1:yE94X0xBFSBQ9LvvJ/zppc4+XeiCAXtsHfYHm15dlcA=
 github.com/libopenstorage/stork v1.4.1-0.20221103082056-65abc8cc4e80/go.mod h1:yX+IlCrUsZekC6zxL6zHE7sBPKIudubHB3EcImzeRbI=
 github.com/libopenstorage/stork v1.4.1-0.20230207013129-a31284f0e973/go.mod h1:/EFTTQyBxNzul96urrYPdjNEYeDzVgZzK88gRQjoVmk=
-github.com/libopenstorage/stork v1.4.1-0.20230519043154-cbc10dffaf19 h1:WPhzOnrA3K6w5SjkP4rll0e32Yun5cBxycPi9NgjdkQ=
-github.com/libopenstorage/stork v1.4.1-0.20230519043154-cbc10dffaf19/go.mod h1:Xm4DHoViynFXMQKBXGj3IkA77LY2RBFkNtv6vbo3wNw=
+github.com/libopenstorage/stork v1.4.1-0.20230601053837-5dd68f026569 h1:R6RKwgLqMqlbknApChYcDke4BfZ0KSLUMQ6MC4zBSNw=
+github.com/libopenstorage/stork v1.4.1-0.20230601053837-5dd68f026569/go.mod h1:+mKPMCPNhS/XOF2RPcNFijkr67CCCWp0o8OXVG6xxAk=
 github.com/libopenstorage/systemutils v0.0.0-20160208220149-44ac83be3ce1/go.mod h1:xwNGC7xiz/BQ/wbMkvHujL8Gjgseg+x41xMek7sKRRQ=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=

--- a/pkg/executor/nfs/nfsrestoreresources.go
+++ b/pkg/executor/nfs/nfsrestoreresources.go
@@ -581,6 +581,8 @@ func applyResources(
 			restore.Spec.IncludeOptionalResourceTypes,
 			restore.Status.Volumes,
 			&opts,
+			restore.Spec.BackupLocation,
+			restore.Namespace,
 		)
 		if err != nil {
 			return err

--- a/pkg/executor/nfs/nfsrestorevolcreate.go
+++ b/pkg/executor/nfs/nfsrestorevolcreate.go
@@ -235,6 +235,8 @@ func restoreVolResourcesAndApply(
 					restore.Spec.IncludeOptionalResourceTypes,
 					nil,
 					&opts,
+					restore.Spec.BackupLocation,
+					restore.Namespace,
 				)
 				if err != nil {
 					log.ApplicationRestoreLog(restore).Errorf("Error from PrepareResourceForApply: %v", err)

--- a/vendor/github.com/libopenstorage/stork/drivers/volume/aws/aws.go
+++ b/vendor/github.com/libopenstorage/stork/drivers/volume/aws/aws.go
@@ -66,6 +66,7 @@ type aws struct {
 	client *ec2.EC2
 	storkvolume.ClusterPairNotSupported
 	storkvolume.MigrationNotSupported
+	storkvolume.ActionNotSupported
 	storkvolume.GroupSnapshotNotSupported
 	storkvolume.ClusterDomainsNotSupported
 	storkvolume.CloneNotSupported
@@ -398,6 +399,8 @@ func (a *aws) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
 	if pv.Spec.CSI != nil {
 		pv.Spec.CSI.VolumeHandle = pv.Name

--- a/vendor/github.com/libopenstorage/stork/drivers/volume/azure/azure.go
+++ b/vendor/github.com/libopenstorage/stork/drivers/volume/azure/azure.go
@@ -55,6 +55,7 @@ type azure struct {
 	snapshotClient compute.SnapshotsClient
 	storkvolume.ClusterPairNotSupported
 	storkvolume.MigrationNotSupported
+	storkvolume.ActionNotSupported
 	storkvolume.GroupSnapshotNotSupported
 	storkvolume.ClusterDomainsNotSupported
 	storkvolume.CloneNotSupported
@@ -409,8 +410,15 @@ func (a *azure) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
-	disk, err := a.diskClient.Get(context.TODO(), a.resourceGroup, pv.Name)
+	azureSession, err := a.getAzureSession(backuplocationName, backuplocationNamespace)
+	if err != nil {
+		return nil, err
+	}
+	diskClient := azureSession.diskClient
+	disk, err := diskClient.Get(context.TODO(), a.resourceGroup, pv.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/libopenstorage/stork/drivers/volume/csi/csi.go
+++ b/vendor/github.com/libopenstorage/stork/drivers/volume/csi/csi.go
@@ -168,6 +168,7 @@ type csi struct {
 
 	storkvolume.ClusterPairNotSupported
 	storkvolume.MigrationNotSupported
+	storkvolume.ActionNotSupported
 	storkvolume.GroupSnapshotNotSupported
 	storkvolume.ClusterDomainsNotSupported
 	storkvolume.CloneNotSupported
@@ -1200,6 +1201,8 @@ func (c *csi) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
 	return pv, nil
 }

--- a/vendor/github.com/libopenstorage/stork/drivers/volume/gcp/gcp.go
+++ b/vendor/github.com/libopenstorage/stork/drivers/volume/gcp/gcp.go
@@ -50,6 +50,7 @@ type gcp struct {
 	service   *compute.Service
 	storkvolume.ClusterPairNotSupported
 	storkvolume.MigrationNotSupported
+	storkvolume.ActionNotSupported
 	storkvolume.GroupSnapshotNotSupported
 	storkvolume.ClusterDomainsNotSupported
 	storkvolume.CloneNotSupported
@@ -363,6 +364,8 @@ func (g *gcp) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
 	if pv.Spec.CSI != nil {
 		key, err := common.VolumeIDToKey(pv.Spec.CSI.VolumeHandle)

--- a/vendor/github.com/libopenstorage/stork/drivers/volume/kdmp/kdmp.go
+++ b/vendor/github.com/libopenstorage/stork/drivers/volume/kdmp/kdmp.go
@@ -98,6 +98,7 @@ var (
 type kdmp struct {
 	storkvolume.ClusterPairNotSupported
 	storkvolume.MigrationNotSupported
+	storkvolume.ActionNotSupported
 	storkvolume.GroupSnapshotNotSupported
 	storkvolume.ClusterDomainsNotSupported
 	storkvolume.CloneNotSupported
@@ -542,6 +543,8 @@ func (k *kdmp) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
 	return pv, nil
 }

--- a/vendor/github.com/libopenstorage/stork/drivers/volume/portworx/portworx.go
+++ b/vendor/github.com/libopenstorage/stork/drivers/volume/portworx/portworx.go
@@ -2459,6 +2459,65 @@ func (p *portworx) DeletePair(pair *storkapi.ClusterPair) error {
 	return nil
 }
 
+func (p *portworx) Failover(action *storkapi.Action) error {
+	namespace := action.Namespace
+	logrus.Infof("volumeDriver failover for namespace %s", namespace)
+
+	pvcList, err := core.Instance().GetPersistentVolumeClaims(namespace, nil)
+	if err != nil {
+		return fmt.Errorf("error fetching pvcList %v", err)
+	}
+
+	countPromotedVolumes := 0
+	countTotalVolumes := len(pvcList.Items)
+	defer func() {
+		logrus.Infof("promoted %v/%v volumes", countPromotedVolumes, countTotalVolumes)
+	}()
+
+	for _, pvc := range pvcList.Items {
+		if !p.OwnsPVC(core.Instance(), &pvc) {
+			continue
+		}
+		if resourcecollector.SkipResource(pvc.Annotations) {
+			continue
+		}
+
+		pvName, err := core.Instance().GetVolumeForPersistentVolumeClaim(&pvc)
+		if err != nil {
+			return fmt.Errorf("error fetching volume for pvc %v", err)
+		}
+
+		volDriver, err := p.getUserVolDriver(pvc.Annotations, namespace)
+		if err != nil {
+			return err
+		}
+
+		volumes, err := volDriver.Inspect([]string{pvName})
+		if err != nil {
+			return err
+		}
+		if len(volumes) != 1 {
+			return &errors.ErrNotFound{
+				ID:   pvName,
+				Type: "Volume",
+			}
+		}
+		vol := volumes[0]
+
+		volLocator := vol.Locator
+		if volLocator.VolumeLabels == nil {
+			volLocator.VolumeLabels = make(map[string]string)
+		}
+		volLocator.VolumeLabels["promote"] = "true"
+		if err := volDriver.Set(vol.GetId(), volLocator, nil); err != nil {
+			return fmt.Errorf("failed to promote volume %v with error %v", vol.GetId(), err)
+		}
+		countPromotedVolumes += 1
+		logrus.Infof("promoted volume %v", vol.GetId())
+	}
+	return nil
+}
+
 func (p *portworx) StartMigration(migration *storkapi.Migration, migrationNamespaces []string) ([]*storkapi.MigrationVolumeInfo, error) {
 	if !p.initDone {
 		if err := p.initPortworxClients(); err != nil {
@@ -2653,6 +2712,8 @@ func (p *portworx) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
 	// Get the pv storageclass and get the provision detail and decide on csi section.
 	if len(pv.Spec.StorageClassName) != 0 {

--- a/vendor/github.com/libopenstorage/stork/drivers/volume/volume.go
+++ b/vendor/github.com/libopenstorage/stork/drivers/volume/volume.go
@@ -153,6 +153,7 @@ type Driver interface {
 	ClusterPairPluginInterface
 	// MigratePluginInterface Interface to migrate data between clusters
 	MigratePluginInterface
+	ActionPluginInterface
 	// ClusterDomainsPluginInterface Interface to manage cluster domains
 	ClusterDomainsPluginInterface
 	// BackupRestorePluginInterface Interface to backup and restore volumes
@@ -198,7 +199,11 @@ type MigratePluginInterface interface {
 	CancelMigration(*storkapi.Migration) error
 	// Update the PVC spec to point to the migrated volume on the destination
 	// cluster
-	UpdateMigratedPersistentVolumeSpec(*v1.PersistentVolume, *storkapi.ApplicationRestoreVolumeInfo, map[string]string) (*v1.PersistentVolume, error)
+	UpdateMigratedPersistentVolumeSpec(*v1.PersistentVolume, *storkapi.ApplicationRestoreVolumeInfo, map[string]string, string, string) (*v1.PersistentVolume, error)
+}
+
+type ActionPluginInterface interface {
+	Failover(*storkapi.Action) error
 }
 
 // ClusterDomainsPluginInterface Interface to manage cluster domains
@@ -444,6 +449,12 @@ func (m *MigrationNotSupported) UpdateMigratedPersistentVolumeSpec(
 	*v1.PersistentVolume,
 ) (*v1.PersistentVolume, error) {
 	return nil, &errors.ErrNotSupported{}
+}
+
+type ActionNotSupported struct{}
+
+func (m *ActionNotSupported) Failover(*storkapi.Action) error {
+	return &errors.ErrNotSupported{}
 }
 
 // GroupSnapshotNotSupported to be used by drivers that don't support group snapshots

--- a/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1938,7 +1938,7 @@ func (a *ApplicationBackupController) createCRD() error {
 		return err
 	}
 	if ok {
-		err := k8sutils.CreateCRD(resource)
+		err := k8sutils.CreateCRDV1(resource)
 		if err != nil && !k8s_errors.IsAlreadyExists(err) {
 			return err
 		}

--- a/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationbackupschedule.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationbackupschedule.go
@@ -521,7 +521,7 @@ func (s *ApplicationBackupScheduleController) createCRD() error {
 		return err
 	}
 	if ok {
-		err := k8sutils.CreateCRD(resource)
+		err := k8sutils.CreateCRDV1(resource)
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return err
 		}

--- a/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationclone.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationclone.go
@@ -547,6 +547,7 @@ func (a *ApplicationCloneController) prepareResources(
 			clone.Spec.IncludeOptionalResourceTypes,
 			nil,
 			&opts,
+			"", "",
 		)
 		if err != nil {
 			return nil, err
@@ -590,7 +591,7 @@ func (a *ApplicationCloneController) preparePVResource(
 		return err
 	}
 
-	_, err := a.volDriver.UpdateMigratedPersistentVolumeSpec(&pv, nil, nil)
+	_, err := a.volDriver.UpdateMigratedPersistentVolumeSpec(&pv, nil, nil, "", "")
 	if err != nil {
 		return err
 	}
@@ -818,7 +819,7 @@ func (a *ApplicationCloneController) createCRD() error {
 		return err
 	}
 	if ok {
-		err := k8sutils.CreateCRD(resource)
+		err := k8sutils.CreateCRDV1(resource)
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return err
 		}

--- a/vendor/github.com/libopenstorage/stork/pkg/k8sutils/k8sutils.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/k8sutils/k8sutils.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/apps"
 	"github.com/portworx/sched-ops/k8s/core"
@@ -175,8 +176,31 @@ func ValidateCRDV1(client *clientset.Clientset, crdName string) error {
 	})
 }
 
-// CreateCRD creates the given custom resource
-func CreateCRD(resource apiextensions.CustomResource) error {
+// CreateCRD creates the given custom resource for the respective apiextensions version
+func CreateCRD(
+	resource apiextensions.CustomResource,
+	validateCRDTimeout time.Duration,
+	validateCRDInterval time.Duration) error {
+	ok, err := version.RequiresV1Registration()
+	if err != nil {
+		return err
+	}
+	if ok {
+		err := CreateCRDV1(resource)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+		return apiextensions.Instance().ValidateCRD(resource.Plural+"."+resource.Group, validateCRDTimeout, validateCRDInterval)
+	}
+	err = apiextensions.Instance().CreateCRDV1beta1(resource)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	return apiextensions.Instance().ValidateCRDV1beta1(resource, validateCRDTimeout, validateCRDInterval)
+}
+
+// CreateCRDV1 creates the given custom resource for apiextensionsV1
+func CreateCRDV1(resource apiextensions.CustomResource) error {
 	scope := apiextensionsv1.NamespaceScoped
 	if string(resource.Scope) == string(apiextensionsv1.ClusterScoped) {
 		scope = apiextensionsv1.ClusterScoped

--- a/vendor/github.com/libopenstorage/stork/pkg/log/log.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/log/log.go
@@ -301,3 +301,14 @@ func BackupLocationLog(location *storkv1.BackupLocation) *logrus.Entry {
 
 	return logrus.WithFields(logrus.Fields{})
 }
+
+// ActionLog formats a log message with action information
+func ActionLog(action *storkv1.Action) *logrus.Entry {
+	if action != nil {
+		return logrus.WithFields(logrus.Fields{
+			"ActionName": action.Name,
+			"Namespace":  action.Namespace,
+		})
+	}
+	return logrus.WithFields(logrus.Fields{})
+}

--- a/vendor/github.com/libopenstorage/stork/pkg/resourcecollector/persistentvolume.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/resourcecollector/persistentvolume.go
@@ -144,6 +144,8 @@ func (r *ResourceCollector) preparePVResourceForApply(
 	storageClassMappings map[string]string,
 	namespaceMappings map[string]string,
 	opts Options,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (bool, error) {
 	var updatedName string
 	var present bool
@@ -215,7 +217,7 @@ func (r *ResourceCollector) preparePVResourceForApply(
 	if err != nil {
 		return false, err
 	}
-	_, err = driver.UpdateMigratedPersistentVolumeSpec(&pv, volumeInfo, namespaceMappings)
+	_, err = driver.UpdateMigratedPersistentVolumeSpec(&pv, volumeInfo, namespaceMappings, backuplocationName, backuplocationNamespace)
 	if err != nil {
 		return false, err
 	}

--- a/vendor/github.com/libopenstorage/stork/pkg/resourcecollector/resourcecollector.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/resourcecollector/resourcecollector.go
@@ -980,6 +980,8 @@ func (r *ResourceCollector) PrepareResourceForApply(
 	optionalResourceTypes []string,
 	vInfo []*stork_api.ApplicationRestoreVolumeInfo,
 	opts *Options,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (bool, error) {
 	objectType, err := meta.TypeAccessor(object)
 	if err != nil {
@@ -1015,7 +1017,7 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		}
 		return true, nil
 	case "PersistentVolume":
-		return r.preparePVResourceForApply(object, pvNameMappings, vInfo, storageClassMappings, namespaceMappings, *opts)
+		return r.preparePVResourceForApply(object, pvNameMappings, vInfo, storageClassMappings, namespaceMappings, *opts, backuplocationName, backuplocationNamespace)
 	case "PersistentVolumeClaim":
 		return r.preparePVCResourceForApply(object, allObjects, pvNameMappings, storageClassMappings, vInfo, *opts)
 	case "ClusterRoleBinding":

--- a/vendor/github.com/libopenstorage/stork/pkg/rule/rule.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/rule/rule.go
@@ -116,7 +116,7 @@ func Init() error {
 		return err
 	}
 	if ok {
-		err := k8sutils.CreateCRD(storkRuleResource)
+		err := k8sutils.CreateCRDV1(storkRuleResource)
 		if err != nil && !k8s_errors.IsAlreadyExists(err) {
 			return err
 		}

--- a/vendor/github.com/libopenstorage/stork/pkg/schedule/schedule.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/schedule/schedule.go
@@ -444,14 +444,14 @@ func createCRD() error {
 		return err
 	}
 	if ok {
-		err := k8sutils.CreateCRD(resource)
+		err := k8sutils.CreateCRDV1(resource)
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return err
 		}
 		if err := apiextensions.Instance().ValidateCRD(resource.Plural+"."+resource.Group, validateCRDTimeout, validateCRDInterval); err != nil {
 			return err
 		}
-		err = k8sutils.CreateCRD(policy)
+		err = k8sutils.CreateCRDV1(policy)
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return err
 		}

--- a/vendor/github.com/libopenstorage/stork/pkg/snapshot/controllers/snapshotrestore.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/snapshot/controllers/snapshotrestore.go
@@ -387,7 +387,7 @@ func (c *SnapshotRestoreController) createCRD() error {
 		return err
 	}
 	if ok {
-		err := k8sutils.CreateCRD(resource)
+		err := k8sutils.CreateCRDV1(resource)
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return err
 		}

--- a/vendor/github.com/libopenstorage/stork/pkg/snapshot/controllers/snapshotschedule.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/snapshot/controllers/snapshotschedule.go
@@ -472,7 +472,7 @@ func (s *SnapshotScheduleController) createCRD() error {
 		return err
 	}
 	if ok {
-		err := k8sutils.CreateCRD(resource)
+		err := k8sutils.CreateCRDV1(resource)
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return err
 		}

--- a/vendor/github.com/libopenstorage/stork/pkg/snapshotter/snapshotter_csi.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/snapshotter/snapshotter_csi.go
@@ -1519,13 +1519,14 @@ func (c *csiDriver) RestoreFromLocalSnapshot(backupLocation *storkapi.BackupLoca
 	}
 
 	// create a new pvc for restore from the snapshot
+	pvcName := pvc.Name
 	pvc, err = c.RestoreVolumeClaim(
 		RestoreSnapshotName(vsName),
 		RestoreNamespace(namespace),
 		PVC(*pvc),
 	)
 	if err != nil {
-		return status, fmt.Errorf("failed to restore pvc %s/%s from csi local snapshot: %v", namespace, pvc.Name, err)
+		return status, fmt.Errorf("failed to restore pvc %s/%s from csi local snapshot: %v", namespace, pvcName, err)
 	}
 	logrus.Debugf("created pvc: %s/%s", pvc.Namespace, pvc.Name)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -384,7 +384,7 @@ github.com/libopenstorage/openstorage-sdk-clients/sdk/golang
 github.com/libopenstorage/secrets
 github.com/libopenstorage/secrets/aws/credentials
 github.com/libopenstorage/secrets/k8s
-# github.com/libopenstorage/stork v1.4.1-0.20230519043154-cbc10dffaf19
+# github.com/libopenstorage/stork v1.4.1-0.20230601053837-5dd68f026569
 ## explicit; go 1.19
 github.com/libopenstorage/stork/drivers
 github.com/libopenstorage/stork/drivers/volume
@@ -495,7 +495,7 @@ github.com/portworx/pxc/pkg/component
 github.com/portworx/pxc/pkg/config
 github.com/portworx/pxc/pkg/kubernetes
 github.com/portworx/pxc/pkg/util
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20230331045738-90076ccca1b6 => github.com/portworx/sched-ops v1.20.4-rc1.0.20230302072046-553cc8ef572b
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20230426231724-8d9f2c104721 => github.com/portworx/sched-ops v1.20.4-rc1.0.20230302072046-553cc8ef572b
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/apiextensions
 github.com/portworx/sched-ops/k8s/apps


### PR DESCRIPTION
**What this PR does / why we need it**:
```

    pb-3907: passing backuplocation CR details to resourceCollector.PrepareResourceForApply

            - Need to call the getAzureSession in UpdateMigratedPersistentVolumeSpec api, which is called in
              preparePVResourceForApply of resourcecollector api.
            - So passing the backuplocation CR details to get the cluster
              creds from the backuplocation CR and get the azure session details.
```

**Which issue(s) this PR fixes** (optional)
Closes # pb-3907

**Special notes for your reviewer**:
Tested on the QA setup. Restore completes.

