### PR TITLE
PB-3911: modifying the order of uploading contents to BL

### DIFF
--- a/pkg/executor/nfs/nfsbkpresources.go
+++ b/pkg/executor/nfs/nfsbkpresources.go
@@ -136,16 +136,9 @@ func uploadBkpResource(
 		logrus.Errorf("%s err: %v", funct, err)
 		return err
 	}
-	err = uploadResource(bkpNamespace, backup, bkpDir, encryptionKey)
+	err = uploadCSISnapshots(bkpNamespace, backup, bkpDir, encryptionKey)
 	if err != nil {
-		errMsg := fmt.Sprintf("%s: error uploading resources: %v", funct, err)
-		logrus.Errorf(errMsg)
-		return fmt.Errorf(errMsg)
-	}
-
-	err = uploadNamespaces(bkpNamespace, backup, bkpDir, encryptionKey)
-	if err != nil {
-		errMsg := fmt.Sprintf("%s: error uploading namespace resource %v", funct, err)
+		errMsg := fmt.Sprintf("%s: error uploading CSI snapshot file %v", funct, err)
 		logrus.Errorf(errMsg)
 		return fmt.Errorf(errMsg)
 	}
@@ -155,9 +148,15 @@ func uploadBkpResource(
 		logrus.Errorf(errMsg)
 		return fmt.Errorf(errMsg)
 	}
-	err = uploadCSISnapshots(bkpNamespace, backup, bkpDir, encryptionKey)
+	err = uploadResource(bkpNamespace, backup, bkpDir, encryptionKey)
 	if err != nil {
-		errMsg := fmt.Sprintf("%s: error uploading CSI snapshot file %v", funct, err)
+		errMsg := fmt.Sprintf("%s: error uploading resources: %v", funct, err)
+		logrus.Errorf(errMsg)
+		return fmt.Errorf(errMsg)
+	}
+	err = uploadNamespaces(bkpNamespace, backup, bkpDir, encryptionKey)
+	if err != nil {
+		errMsg := fmt.Sprintf("%s: error uploading namespace resource %v", funct, err)
 		logrus.Errorf(errMsg)
 		return fmt.Errorf(errMsg)
 	}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: This PR is to have CSI snapshot contents uploaded before resource and namespaces. Thus avoiding the change of missed CSI snapshot content uploads when there is an issue in resource or namespace upload. 

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PB-3911

**Special notes for your reviewer**:

