### PR TITLE
pb-3913: Added failed mount event check in the jobstatus and return error to make the job fail.

### DIFF
--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -207,6 +207,14 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		jobStatus = job.Status.Conditions[0].Type
 
 	}
+
+	// Check whether mount point failure
+	mountFailed := utils.IsJobPodMountFailed(job, namespace)
+	if mountFailed {
+		errMsg := fmt.Sprintf("job [%v/%v] failed while mounting NFS mount endpoint", namespace, name)
+		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
+	}
+
 	err = utils.JobNodeExists(job)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to fetch the node info tied to the job %s/%s: %v", namespace, name, err)

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -116,6 +116,12 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Check whether mount point failure
+        mountFailed := utils.IsJobPodMountFailed(job, namespace)
+        if mountFailed {
+                errMsg := fmt.Sprintf("job [%v/%v] failed while mounting NFS mount endpoint", namespace, name)
+                return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
+        }
 	err = utils.JobNodeExists(job)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to fetch the node info tied to the job %s/%s: %v", namespace, name, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-3913: Added failed mount event check in the jobstatus and return error to make the job fail.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3913

**Special notes for your reviewer**:
**Note: Deletion will be taken care by pb-3915

Testing:**
Tested the backupschedule with unreachable NFS server.

![Screenshot 2023-06-03 at 9 35 59 PM](https://github.com/portworx/kdmp/assets/52188641/2bfccd1c-1ca2-4258-843f-567fc214490b)
![Screenshot 2023-06-03 at 9 35 49 PM](https://github.com/portworx/kdmp/assets/52188641/d945eca0-4d0c-4c42-937b-c55af5f879c1)
