### PR TITLE
 PB-3915: Add IsJobPodMountFailed check in kopiadelete JobStatus

### DIFF
--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -139,6 +139,14 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
+
+	// Check whether mount point failure
+	mountFailed := utils.IsJobPodMountFailed(job, namespace)
+	if mountFailed {
+		errMsg := fmt.Sprintf("job [%v/%v] failed while mounting NFS mount endpoint", namespace, name)
+		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
+	}
+
 	err = utils.JobNodeExists(job)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to fetch the node info tied to the job %s/%s: %v", namespace, name, err)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
pb-3915: Added failed mount event check in the job status and return error to make the job fail. In case of kopia delete.

**Which issue(s) this PR fixes** (optional)
Closes #PB-3915

**Special notes for your reviewer**:
Unit test is in progress.
Currently blocked due to repo access issue
