### PR TITLE
pb-3916: Made the step to update the restore status for both nfs and non nfs case in stageLocalSnapshotRestoreInProgress api

### DIFF
--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -117,11 +117,11 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		return nil, err
 	}
 	// Check whether mount point failure
-        mountFailed := utils.IsJobPodMountFailed(job, namespace)
-        if mountFailed {
-                errMsg := fmt.Sprintf("job [%v/%v] failed while mounting NFS mount endpoint", namespace, name)
-                return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
-        }
+	mountFailed := utils.IsJobPodMountFailed(job, namespace)
+	if mountFailed {
+		errMsg := fmt.Sprintf("job [%v/%v] failed while mounting NFS mount endpoint", namespace, name)
+		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
+	}
 	err = utils.JobNodeExists(job)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to fetch the node info tied to the job %s/%s: %v", namespace, name, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-3916: Made the step to update the restore status for both nfs and non nfs case in stageLocalSnapshotRestoreInProgress api
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3916

**Special notes for your reviewer**:
Testing:
Tested both the nfs and S3 backuplocation with KDMP Localsnapshot restore. Now size show properly.
![Screenshot 2023-06-07 at 6 29 24 PM](https://github.com/portworx/kdmp/assets/52188641/a15ce490-b7fa-4aac-9bf2-36dbeed6727b)

