### PR TITLE
PB-3936: Fixed the issue in taking crds backup with nfs backuplocation.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7
-	github.com/libopenstorage/stork v1.4.1-0.20230601053837-5dd68f026569
+	github.com/libopenstorage/stork v1.4.1-0.20230610103146-72cf75320066
 	github.com/portworx/pxc v0.33.0
 	github.com/portworx/sched-ops v1.20.4-rc1.0.20230426231724-8d9f2c104721
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1784,8 +1784,8 @@ github.com/libopenstorage/stork v1.4.1-0.20220323180113-0ea773109d05/go.mod h1:h
 github.com/libopenstorage/stork v1.4.1-0.20220414104250-3c18fd21ed95/go.mod h1:yE94X0xBFSBQ9LvvJ/zppc4+XeiCAXtsHfYHm15dlcA=
 github.com/libopenstorage/stork v1.4.1-0.20221103082056-65abc8cc4e80/go.mod h1:yX+IlCrUsZekC6zxL6zHE7sBPKIudubHB3EcImzeRbI=
 github.com/libopenstorage/stork v1.4.1-0.20230207013129-a31284f0e973/go.mod h1:/EFTTQyBxNzul96urrYPdjNEYeDzVgZzK88gRQjoVmk=
-github.com/libopenstorage/stork v1.4.1-0.20230601053837-5dd68f026569 h1:R6RKwgLqMqlbknApChYcDke4BfZ0KSLUMQ6MC4zBSNw=
-github.com/libopenstorage/stork v1.4.1-0.20230601053837-5dd68f026569/go.mod h1:+mKPMCPNhS/XOF2RPcNFijkr67CCCWp0o8OXVG6xxAk=
+github.com/libopenstorage/stork v1.4.1-0.20230610103146-72cf75320066 h1:s8OgtWGDLypt5bRi53EXk8oFC2en4IcFGNoXSw99aUQ=
+github.com/libopenstorage/stork v1.4.1-0.20230610103146-72cf75320066/go.mod h1:Yst+fnOYjWk6SA5pXZBKm19wtiinjxQ/vgYTXI3k80Q=
 github.com/libopenstorage/systemutils v0.0.0-20160208220149-44ac83be3ce1/go.mod h1:xwNGC7xiz/BQ/wbMkvHujL8Gjgseg+x41xMek7sKRRQ=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=

--- a/vendor/github.com/libopenstorage/stork/drivers/volume/csi/csi.go
+++ b/vendor/github.com/libopenstorage/stork/drivers/volume/csi/csi.go
@@ -758,7 +758,7 @@ func (c *csi) cleanupSnapshots(
 			}
 		}
 		for _, vsc := range vsContentMap.(map[string]*kSnapshotv1.VolumeSnapshotContent) {
-			err := c.snapshotClient.SnapshotV1beta1().VolumeSnapshotContents().Delete(context.TODO(), vsc.Name, metav1.DeleteOptions{})
+			err := c.snapshotClient.SnapshotV1().VolumeSnapshotContents().Delete(context.TODO(), vsc.Name, metav1.DeleteOptions{})
 			if k8s_errors.IsNotFound(err) {
 				continue
 			} else if err != nil {

--- a/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationbackup.go
@@ -993,7 +993,7 @@ func (a *ApplicationBackupController) prepareResources(
 	return nil
 }
 
-func (a *ApplicationBackupController) updateRancherProjectDetails(
+func UpdateRancherProjectDetails(
 	backup *stork_api.ApplicationBackup,
 	objects []runtime.Unstructured,
 ) error {
@@ -1005,14 +1005,14 @@ func (a *ApplicationBackupController) updateRancherProjectDetails(
 		return err
 	}
 	if platformCredential.Spec.Type == stork_api.PlatformCredentialRancher {
-		if err = updateRancherProjects(platformCredential, backup, objects); err != nil {
+		if err = UpdateRancherProjects(platformCredential, backup, objects); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func updateRancherProjects(
+func UpdateRancherProjects(
 	platformCredential *stork_api.PlatformCredential,
 	backup *stork_api.ApplicationBackup,
 	objects []runtime.Unstructured,
@@ -1671,7 +1671,7 @@ func (a *ApplicationBackupController) backupResources(
 
 	// get and update rancher project details
 	if len(backup.Spec.PlatformCredential) != 0 {
-		if err = a.updateRancherProjectDetails(backup, allObjects); err != nil {
+		if err = UpdateRancherProjectDetails(backup, allObjects); err != nil {
 			message := fmt.Sprintf("Error updating rancher project details for backup: %v", err)
 			backup.Status.Status = stork_api.ApplicationBackupStatusFailed
 			backup.Status.Stage = stork_api.ApplicationBackupStageFinal

--- a/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationrestore.go
@@ -537,7 +537,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 		namespacedName,
 		storkapi.ApplicationRestoreStatusInProgress,
 		storkapi.ApplicationRestoreStageVolumes,
-		"Volume or Resource(kdmp) restores are in progress",
+		"Volume or Resource restores are in progress",
 		nil,
 	)
 	if err != nil {
@@ -1920,6 +1920,9 @@ func (a *ApplicationRestoreController) restoreResources(
 	} else {
 		restore.Status.ResourceCount = len(restore.Status.Resources)
 	}
+
+	// Let's accomodate the PV-PVC counts in RestoredResourceCount, specifically for CSI & kdmp case.
+	restore.Status.RestoredResourceCount = restore.Status.ResourceCount
 
 	restore.Status.Stage = storkapi.ApplicationRestoreStageFinal
 	restore.Status.FinishTimestamp = metav1.Now()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -384,7 +384,7 @@ github.com/libopenstorage/openstorage-sdk-clients/sdk/golang
 github.com/libopenstorage/secrets
 github.com/libopenstorage/secrets/aws/credentials
 github.com/libopenstorage/secrets/k8s
-# github.com/libopenstorage/stork v1.4.1-0.20230601053837-5dd68f026569
+# github.com/libopenstorage/stork v1.4.1-0.20230610103146-72cf75320066
 ## explicit; go 1.19
 github.com/libopenstorage/stork/drivers
 github.com/libopenstorage/stork/drivers/volume


### PR DESCRIPTION
**What this PR does / why we need it**:
```
 PB-3936: Fixed the issue in taking crds backup with nfs backuplocation.

            - Also fixed the way the resource is fetched in the nfs resource
              job pod.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-3936

**Special notes for your reviewer**:
```
Tested below cases:
1) Validated backup and restore of the elastic search deployment deployed by the operatore.
2) backup of multi namespace with resourceType - with one namespace ns1 having resourceType and another one namespace ns2 with out ns.
      - In this case, the resourceType's resource of the ns1 was backedup. No resources from ns2 was backed up.
3) backup of multi namespace with includeresource and all resource - with includeResource one namespace ns1 and all resources with another namespace ns2.
      - In thie case, custom resources from ns1 and all resources in the ns2 was backed up.
4) backup of whole namespace of two namespace.
      - all the resources in both the ns backed up.
```
