### PR TITLE
pb-3927: cleanup unwanted resources after a successful restore operation

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -1435,6 +1435,16 @@ func (c *Controller) cleanUp(driver drivers.Interface, de *kdmpapi.DataExport) e
 		if err := core.Instance().DeletePersistentVolume(pvName); err != nil && !k8sErrors.IsNotFound(err) {
 			return fmt.Errorf("delete %s pv: %s", pvName, err)
 		}
+		if err := utils.CleanServiceAccount(jobName, namespace); err != nil {
+			errMsg := fmt.Sprintf("deletion of service account %s/%s failed: %v", namespace, jobName, err)
+			logrus.Errorf("%s: %v", "cleanUp", errMsg)
+			return fmt.Errorf(errMsg)
+		}
+		if err := core.Instance().DeleteSecret(utils.GetCredSecretName(jobName), namespace); err != nil && !k8sErrors.IsNotFound(err) {
+			errMsg := fmt.Sprintf("deletion of backup credential secret %s failed: %v", jobName, err)
+			logrus.Errorf(errMsg)
+			return fmt.Errorf(errMsg)
+		}
 	}
 
 	if err := core.Instance().DeleteSecret(utils.GetCredSecretName(de.Name), namespace); err != nil && !k8sErrors.IsNotFound(err) {
@@ -2187,7 +2197,8 @@ func startNfsCSIRestoreVolumeJob(
 	bl *storkapi.BackupLocation,
 ) (string, error) {
 
-	err := utils.CreateNfsSecret(utils.GetCredSecretName(de.Name), bl, de.Namespace, nil)
+	jobName := utils.GetCsiRestoreJobName(drivers.NFSCSIRestore, de.Name)
+	err := utils.CreateNfsSecret(utils.GetCredSecretName(jobName), bl, de.Namespace, nil)
 	if err != nil {
 		logrus.Errorf("failed to create NFS cred secret: %v", err)
 		return "", fmt.Errorf("failed to create NFS cred secret: %v", err)

--- a/pkg/controllers/resourceexport/reconcile.go
+++ b/pkg/controllers/resourceexport/reconcile.go
@@ -239,7 +239,7 @@ func (c *Controller) cleanupResources(resourceExport *kdmpapi.ResourceExport) er
 	// clean up resources
 	rbNamespace, rbName, err := utils.ParseJobID(resourceExport.Status.TransferID)
 	if err != nil {
-		errMsg := fmt.Sprintf("failed to parse job ID %v from ResourceeExport CR: %v: %v",
+		errMsg := fmt.Sprintf("failed to parse job ID %v from ResourceExport CR: %v: %v",
 			resourceExport.Status.TransferID, resourceExport.Name, err)
 		logrus.Errorf("%v", errMsg)
 		return err

--- a/pkg/drivers/utils/common.go
+++ b/pkg/drivers/utils/common.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	version "github.com/hashicorp/go-version"
@@ -56,6 +57,11 @@ var (
 	// JobPodBackOffLimit backofflimit for the job
 	JobPodBackOffLimit = int32(10)
 )
+
+// GetCsiRestoreJobName returns a CSI restore Job name based on name of the CR
+func GetCsiRestoreJobName(jobPrefix string, crName string) string {
+	return jobPrefix + strings.SplitN(crName, "restore", 2)[1]
+}
 
 // isServiceAccountSecretMissing returns true, if the K8s version does not support secret token for the service account.
 func isServiceAccountSecretMissing() (bool, error) {
@@ -140,6 +146,12 @@ func CleanServiceAccount(name, namespace string) error {
 	}
 	if err := coreops.Instance().DeleteServiceAccount(name, namespace); err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("delete %s/%s serviceaccount: %s", namespace, name, err)
+	}
+	if err := rbacops.Instance().DeleteClusterRole(name); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("delete %s/%s clusterrole: %s", namespace, name, err)
+	}
+	if err := rbacops.Instance().DeleteClusterRoleBinding(name); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("delete %s/%s clusterrolebinding: %s", namespace, name, err)
 	}
 	return nil
 }

--- a/pkg/executor/nfs/nfscsirestore.go
+++ b/pkg/executor/nfs/nfscsirestore.go
@@ -119,29 +119,6 @@ func restoreCSIVolume(
 		return fmt.Errorf(msg)
 	}
 
-	// This will create a unique secret per PVC being restored
-	// For restore create the secret in the ns where PVC is referenced
-	err = CreateCredentialsSecret(
-		dataExport.Name,
-		vb.Spec.BackupLocation.Name,
-		vb.Spec.BackupLocation.Namespace,
-		dataExport.Spec.Destination.Namespace,
-		dataExport.Labels,
-	)
-	if err != nil {
-		msg := fmt.Sprintf("failed to create cloud credential secret during local snapshot restore: %v", err)
-		logrus.Errorf("%s: %v", fn, msg)
-		status := &executor.Status{
-			LastKnownError: fmt.Errorf(msg),
-		}
-		if err = executor.WriteVolumeBackupStatus(status, volumeBackupName, deCrNamespace); err != nil {
-			errMsg := fmt.Sprintf("failed to write a VolumeBackup status after hitting error [%s]: %v", msg, err)
-			logrus.Errorf("%v", errMsg)
-			return fmt.Errorf(errMsg)
-		}
-		return fmt.Errorf(msg)
-	}
-
 	repo, rErr := executor.ParseCloudCred()
 	if rErr != nil {
 		errMsg := fmt.Sprintf("%s: error parsing cloud cred: %v", fn, rErr)


### PR DESCRIPTION
- Cleaned up the below resources after successful completion of restore
   - serviceAccount
   - clusterRole & clusterRoleBinding
   - cred-secret
- Removed an unwanted cred-secret creation logic
- Added deletion logic to clear CRB and clusterRole in utility function

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: It cleans up some unwanted resources after a successful restore operation

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

