### PR TITLE
PB-4074, PB-4075 : fixing high security CVEs

### DIFF
--- a/Dockerfile.kopia
+++ b/Dockerfile.kopia
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 
 MAINTAINER Portworx Inc. <support@portworx.com>
 
-RUN microdnf install bash curl vim make wget gpg ca-certificates yum && \
+RUN microdnf install -y bash vim make wget gpg ca-certificates yum && \
         microdnf clean all
 
 RUN rpm --import https://kopia.io/signing-key

--- a/Dockerfile.nfs
+++ b/Dockerfile.nfs
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 
 MAINTAINER Portworx Inc. <support@portworx.com>
 
-RUN microdnf install bash curl vim make wget gpg ca-certificates yum && \
+RUN microdnf install -y bash vim make wget gpg ca-certificates yum && \
         microdnf clean all
 
 WORKDIR /


### PR DESCRIPTION


<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  fixing high security CVEs
Upgraded to ubi9 as a base image and removed curl package as it comes as a part of the base image

**Which issue(s) this PR fixes** (optional)
Closes # 
kopiaexecutor : [PB-4074](https://portworx.atlassian.net/browse/PB-4074)
nfsexecutor : [PB-4075](https://portworx.atlassian.net/browse/PB-4075)

**Special notes for your reviewer**:



[PB-4074]: https://portworx.atlassian.net/browse/PB-4074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PB-4075]: https://portworx.atlassian.net/browse/PB-4075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ