### PR TITLE
pb-4072: Added alreadyExists error for the resourceBackup CR creation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: focal
 language: go
 env:
   global:

--- a/pkg/controllers/resourceexport/reconcile.go
+++ b/pkg/controllers/resourceexport/reconcile.go
@@ -111,7 +111,7 @@ func (c *Controller) process(ctx context.Context, in *kdmpapi.ResourceExport) (b
 	case kdmpapi.ResourceExportStageInitial:
 		// Create ResourceBackup CR
 		err = createResourceBackup(resourceExport.Name, resourceExport.Namespace)
-		if err != nil {
+		if err != nil && !k8sErrors.IsAlreadyExists(err) {
 			updateData := updateResourceExportFields{
 				stage:  kdmpapi.ResourceExportStageFinal,
 				status: kdmpapi.ResourceExportStatusFailed,


### PR DESCRIPTION
**What this PR does / why we need it**:
```
    pb-4072: Added alreadyExists error for the resourceBackup CR creation.

            - Sometime, if the stork restart the reconcile enters again with
              kdmpapi.ResourceExportStageInitial stage and tries to create the
              resourceBackup again and it fails if it already exists.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-4072

**Special notes for your reviewer**:
Testing:
The bug was found in one of the system testing that trying to restart the stork pod, when backup/restore was in-progress.
With the fix, verified that system test run passes.

