### PR TITLE
PB-4110 - Handle snapshot delete when s3 objects are removed or when snapshot already deleted

### DIFF
--- a/pkg/executor/common.go
+++ b/pkg/executor/common.go
@@ -141,6 +141,8 @@ type Status struct {
 	TotalBytes uint64
 	// SnapshotID is the snapshot ID of the backup being handled
 	SnapshotID string
+	// SnapshotIDs is the list of Snapshot Ids existing in the repository
+	SnapshotIDs []string
 	// Done indicates if the operation has completed
 	Done bool
 	// LastKnownError is the last known error of the command

--- a/pkg/executor/kopia/kopiadelete.go
+++ b/pkg/executor/kopia/kopiadelete.go
@@ -83,6 +83,31 @@ func runDelete(snapshotID, volumeBackupDeleteName, volumeBackupDeleteNamespace s
 		return fmt.Errorf(errMsg)
 	}
 
+	snapshotList, err := runKopiaSnapshotList(repo)
+	if err != nil {
+		errMsg := fmt.Sprintf("snapshot list failed: %v", err)
+		logrus.Errorf("%s: %v", fn, errMsg)
+		if err := executor.WriteVolumeBackupDeleteStatus(kdmpapi.VolumeBackupDeleteStatusFailed, errMsg, volumeBackupDeleteName, volumeBackupDeleteNamespace); err != nil {
+			errMsg := fmt.Sprintf("failed in updating VolumeBackupDelete CR [%s:%s]: %v", volumeBackupDeleteName, volumeBackupDeleteNamespace, err)
+			logrus.Errorf("%v", errMsg)
+			return fmt.Errorf(errMsg)
+		}
+		return fmt.Errorf(errMsg)
+	}
+
+	var snapshotIdFound bool
+	for _, data := range snapshotList {
+		if data == snapshotID {
+			snapshotIdFound = true
+			break
+		}
+	}
+
+	if !snapshotIdFound {
+		logrus.Warnf("the snapshot ID [%v] does not exist in the backup location and thus cannot be deleted", snapshotID)
+		return nil
+	}
+
 	if err := runKopiaDelete(repo, snapshotID); err != nil {
 		errMsg := fmt.Sprintf("snapshot [%v] delete failed: %v", snapshotID, err)
 		logrus.Errorf("%s: %v", fn, errMsg)
@@ -99,6 +124,7 @@ func runDelete(snapshotID, volumeBackupDeleteName, volumeBackupDeleteNamespace s
 
 func runKopiaDelete(repository *executor.Repository, snapshotID string) error {
 	fn := "runKopiaDelete:"
+	logrus.Infof("kopia delete started")
 	deleteCmd, err := kopia.GetDeleteCommand(
 		snapshotID,
 	)
@@ -128,5 +154,39 @@ func runKopiaDelete(repository *executor.Repository, snapshotID string) error {
 			break
 		}
 	}
+	logrus.Infof("successfully delete snapshot with ID : [%v]", snapshotID)
 	return nil
+}
+
+func runKopiaSnapshotList(repository *executor.Repository) ([]string, error) {
+	var err error
+	var listCmd *kopia.Command
+	logrus.Infof("Executing kopia snapshot list command")
+	listCmd, err = kopia.GetListCommand()
+
+	if err != nil {
+		return nil, err
+	}
+
+	listExecutor := kopia.NewListExecutor(listCmd)
+	if err := listExecutor.Run(); err != nil {
+		err = fmt.Errorf("failed to run snapshot list command: %v", err)
+		return nil, err
+	}
+
+	for {
+		time.Sleep(progressCheckInterval)
+		status, err := listExecutor.Status()
+		if err != nil {
+			return nil, err
+		}
+		if status.LastKnownError != nil {
+			return nil, status.LastKnownError
+		}
+
+		if status.Done {
+			logrus.Infof("kopia snapshot list command executed successfully")
+			return status.SnapshotIDs, nil
+		}
+	}
 }

--- a/pkg/kopia/command.go
+++ b/pkg/kopia/command.go
@@ -412,6 +412,30 @@ func (c *Command) MaintenanceRunCmd() *exec.Cmd {
 	return cmd
 }
 
+// SnapshotListCmd returns os/exec.Cmd object for the kopia snapshot list Command
+func (c *Command) SnapshotListCmd() *exec.Cmd {
+	// Get all the flags
+	argsSlice := []string{
+		c.Name, // snapshot list command
+		"list",
+		"--show-identical",
+		"--all",
+		"--json",
+		"--config-file",
+		configFile,
+	}
+	argsSlice = append(argsSlice, c.Flags...)
+	// Get the cmd args
+	argsSlice = append(argsSlice, c.Args...)
+	cmd := exec.Command(baseCmd, argsSlice...)
+	if len(c.Env) > 0 {
+		cmd.Env = append(os.Environ(), c.Env...)
+	}
+	cmd.Dir = c.Dir
+
+	return cmd
+}
+
 // MaintenanceSetCmd returns os/exec.Cmd object for the kopia maintenance set Command
 func (c *Command) MaintenanceSetCmd() *exec.Cmd {
 	// Get all the flags

--- a/pkg/kopia/list.go
+++ b/pkg/kopia/list.go
@@ -1,0 +1,106 @@
+package kopia
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+
+	cmdexec "github.com/portworx/kdmp/pkg/executor"
+	"github.com/sirupsen/logrus"
+)
+
+// ListSummaryResponse describes single snapshot list entry.
+type ListSummaryResponse struct {
+	ID string `json:"id"`
+}
+
+type listExecutor struct {
+	cmd       *Command
+	execCmd   *exec.Cmd
+	outBuf    *bytes.Buffer
+	errBuf    *bytes.Buffer
+	lastError error
+	isRunning bool
+}
+
+// GetListCommand returns a wrapper over the kopia snapshot list command
+func GetListCommand() (*Command, error) {
+	return &Command{
+		Name: "snapshot",
+	}, nil
+}
+
+// NewListExecutor returns an instance of Executor that can be used for
+// running a kopia snapshot list command
+func NewListExecutor(cmd *Command) Executor {
+	return &listExecutor{
+		cmd:    cmd,
+		outBuf: new(bytes.Buffer),
+		errBuf: new(bytes.Buffer),
+	}
+}
+
+func (b *listExecutor) Run() error {
+	b.execCmd = b.cmd.SnapshotListCmd()
+	b.execCmd.Stdout = b.outBuf
+	b.execCmd.Stderr = b.errBuf
+
+	if err := b.execCmd.Start(); err != nil {
+		b.lastError = err
+		return err
+	}
+
+	b.isRunning = true
+
+	go func() {
+		err := b.execCmd.Wait()
+
+		if err != nil {
+			b.lastError = fmt.Errorf("failed to run the kopia snapshot list command: %v"+
+				" stdout: %v stderr: %v", err, b.outBuf.String(), b.errBuf.String())
+			logrus.Errorf("%v", b.lastError)
+			return
+		}
+		b.isRunning = false
+	}()
+
+	return nil
+}
+
+func (b *listExecutor) Status() (*cmdexec.Status, error) {
+	if b.lastError != nil {
+		fmt.Fprintln(os.Stderr, b.errBuf.String())
+		return &cmdexec.Status{
+			LastKnownError: b.lastError,
+			Done:           true,
+		}, nil
+	}
+	if b.isRunning {
+		return &cmdexec.Status{
+			Done:           false,
+			LastKnownError: nil,
+		}, nil
+	}
+
+	var listSummaryResponses []ListSummaryResponse
+	err := json.Unmarshal(b.outBuf.Bytes(), &listSummaryResponses)
+	if err != nil {
+		return &cmdexec.Status{
+			Done:           true,
+			LastKnownError: err,
+		}, nil
+	}
+	var snapshotIds []string
+	for _, listSummaryResponse := range listSummaryResponses {
+		snapshotIds = append(snapshotIds, listSummaryResponse.ID)
+
+	}
+
+	return &cmdexec.Status{
+		Done:           true,
+		SnapshotIDs:    snapshotIds,
+		LastKnownError: nil,
+	}, nil
+}


### PR DESCRIPTION

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: This PR add the functional to perform snapshot list before deleting any snapshots and carries out the below
1. When the snapshot to be deleted is not found in the kopia repository(i.e snapshot list), delete job does not proceed on `kopia delete` 
2. When the snapshot to be deleted is found in the snapshot list , delete job will proceed on `kopia delete`

**Which issue(s) this PR fixes** (optional)
Closes #[PB-4110]( https://portworx.atlassian.net/browse/PB-4110)

**Special notes for your reviewer**:

Scenario 1 - When kopia snapshot is already deleted before before triggering backup object delete

![Screenshot from 2023-08-10 14-06-36](https://github.com/portworx/kdmp/assets/101168875/3ed71621-4489-4f81-bbd8-92b9b7057e54)


![Screenshot from 2023-08-10 13-57-56](https://github.com/portworx/kdmp/assets/101168875/1f2f665d-9e49-4bdd-b91f-a1eb1c9e61f5)

Scenario 2 - Normal flow of kdmp+localsnapshot delete

![Screenshot from 2023-08-10 13-53-16](https://github.com/portworx/kdmp/assets/101168875/1a56af25-f2b0-41a3-81cb-7075c53099c9)


![Screenshot from 2023-08-10 13-52-52](https://github.com/portworx/kdmp/assets/101168875/406776c6-4688-47c8-b1b6-54e543fe37e1)


![Screenshot from 2023-08-10 13-52-39](https://github.com/portworx/kdmp/assets/101168875/83f5066f-fcd5-4601-bdd0-a625ee9cdede)






[PB-4110]: https://portworx.atlassian.net/browse/PB-4110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ