### PR TITLE
pb-4237: Resetting the dataexport's SnapshotStorageClass value to empty

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -1066,6 +1066,7 @@ func (c *Controller) stageLocalSnapshotRestore(ctx context.Context, dataExport *
 			reason:                    "switching to restore from objectstore bucket as restoring from local snapshot did not happen",
 			resetLocalSnapshotRestore: true,
 		}
+		logrus.Infof("%v: In stageLocalSnapshotRestore stage, local snapshot restore failed, trying KDMP restore.", dataExport.Name)
 		return false, c.updateStatus(dataExport, data)
 	}
 
@@ -1212,6 +1213,7 @@ func (c *Controller) stageLocalSnapshotRestoreInProgress(ctx context.Context, da
 		if err != nil {
 			logrus.Errorf("cleaning up temporary resources for restoring from snapshot failed for data export %s/%s: %v", dataExport.Namespace, dataExport.Name, err)
 		}
+		logrus.Infof("%v: In stageLocalSnapshotRestoreInProgress stage, local snapshot restore failed, trying KDMP restore.", dataExport.Name)
 		data := updateDataExportDetail{
 			stage:                     kdmpapi.DataExportStageTransferScheduled,
 			status:                    kdmpapi.DataExportStatusInitial,
@@ -1601,6 +1603,8 @@ func (c *Controller) updateStatus(de *kdmpapi.DataExport, data updateDataExportD
 			de.Status.VolumeSnapshot = data.volumeSnapshot
 		}
 		if data.resetLocalSnapshotRestore {
+			// Resetting the SnapshotStorageClass to empty, when ever we try kopia restore, if localsnapshot restore fail.
+			de.Spec.SnapshotStorageClass = ""
 			de.Status.LocalSnapshotRestore = false
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
```
 pb-4237: Resetting the dataexport's SnapshotStorageClass value to empty

            - If the local snapshot restore fails, we decide to try the
              kopia restore. In that we will reset the dataexport's
              SnapshotStorageClass value to empty, so that during cleanup, we will not
              check for any local snapshot resource cleanup.
            - The localsnapshot restore resources will be cleanup, before
              starting the kopia restore.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-4237

**Special notes for your reviewer**:
Testing:
1) The issue was easily reproduced by restoring KDMP Localsnapshot backup on a cluster that does not have volumesnapshotclass.
2) In this case, the localsnapshot restore will fail and we will try Kopia restore.
3) With out fix, the kopia restore failed in the cleanup stage as the dataexport CR was having volumesnapshotclass value.
4) So reset the volumesnapshotclass to empty, when ever we decide to move to kopia restore.
Validated the fix in a setup by manually deleting the volumesnapshot class. The local snapshot restore failed and kopia restore completed successfully.
![Screenshot 2023-08-21 at 2 19 43 PM](https://github.com/portworx/kdmp/assets/52188641/135acf53-3731-4181-b3a9-95241498d202)

