### PR TITLE
PB-4338 : Upgraded go lang version to 1.20.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   global:
     - GO111MODULE=on
 go:
-  - 1.19
+  - 1.20
 script:
   - |
     if [ -n "${TRAVIS_TAG}" ]; then

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BASE_DIR    := $(shell git rev-parse --show-toplevel)
 GIT_SHA     := $(shell git rev-parse --short HEAD)
 BIN         := $(BASE_DIR)/bin
 
-DOCK_BUILD_CNT  := golang:1.19.1
+DOCK_BUILD_CNT  := golang:1.20.5
 
 DOCKER_IMAGE_REPO?=portworx
 DOCKER_IMAGE_NAME?=kdmp
@@ -81,7 +81,7 @@ vet:
 staticcheck:
 	docker run --rm -v $(shell pwd):/go/src/github.com/portworx/kdmp $(DOCK_BUILD_CNT) \
 		/bin/bash -c "cd /go/src/github.com/portworx/kdmp; \
-	go install honnef.co/go/tools/cmd/staticcheck@v0.3.3; \
+	go install honnef.co/go/tools/cmd/staticcheck@v0.4.5; \
 	staticcheck $(PKGS); \
 	staticcheck -tags unittest $(PKGS)"
 
@@ -127,7 +127,7 @@ build-kdmp:
 	@echo "Build kdmp"
 	docker run --rm -v $(shell pwd):/go/src/github.com/portworx/kdmp $(DOCK_BUILD_CNT) \
 		/bin/bash -c 'cd /go/src/github.com/portworx/kdmp/cmd/kdmp; \
-	GOOS=linux go build -ldflags="-s -w \
+	GOOS=linux go build -buildvcs=false -ldflags="-s -w \
 	-X github.com/portworx/kdmp/pkg/version.gitVersion=${RELEASE_VER} \
 	-X github.com/portworx/kdmp/pkg/version.gitCommit=${GIT_SHA} \
 	-X github.com/portworx/kdmp/pkg/version.buildDate=${BUILD_DATE} \
@@ -135,7 +135,7 @@ build-kdmp:
 	-X github.com/portworx/kdmp/pkg/version.minor=${MINOR_VERSION} \
 	-X github.com/portworx/kdmp/pkg/version.patch=${PATCH_VERSION}" \
 	-o /go/src/github.com/portworx/kdmp/bin/kdmp \
-	-a /go/src/github.com/portworx/kdmp/cmd/kdmp;'
+	-a /go/src/github.com/portworx/kdmp/cmd/kdmp;' 
 
 container-kdmp:
 	@echo "Build kdmp docker image"
@@ -161,7 +161,7 @@ build-restic-executor:
 	@echo "Build restic-executor"
 	docker run --rm -v $(shell pwd):/go/src/github.com/portworx/kdmp $(DOCK_BUILD_CNT) \
 		/bin/bash -c 'cd /go/src/github.com/portworx/kdmp/cmd/executor/restic; \
-	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w \
+	CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -ldflags="-s -w \
 	-X github.com/portworx/kdmp/pkg/version.gitVersion=${RELEASE_VER} \
 	-X github.com/portworx/kdmp/pkg/version.gitCommit=${GIT_SHA} \
 	-X github.com/portworx/kdmp/pkg/version.buildDate=${BUILD_DATE}" \
@@ -172,7 +172,7 @@ build-kopia-executor:
 	@echo "Build kopia-executor"
 	docker run --rm -v $(shell pwd):/go/src/github.com/portworx/kdmp $(DOCK_BUILD_CNT) \
 		/bin/bash -c 'cd /go/src/github.com/portworx/kdmp/cmd/executor/kopia; \
-	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w \
+	CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -ldflags="-s -w \
 	-X github.com/portworx/kdmp/pkg/version.gitVersion=${RELEASE_VER} \
 	-X github.com/portworx/kdmp/pkg/version.gitCommit=${GIT_SHA} \
 	-X github.com/portworx/kdmp/pkg/version.buildDate=${BUILD_DATE}" \
@@ -183,7 +183,7 @@ build-nfs-executor:
 	@echo "Build nfs-executor"
 	docker run --rm -v $(shell pwd):/go/src/github.com/portworx/kdmp $(DOCK_BUILD_CNT) \
 		/bin/bash -c 'cd /go/src/github.com/portworx/kdmp/cmd/executor/nfs; \
-	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w \
+	CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -ldflags="-s -w \
 	-X github.com/portworx/kdmp/pkg/version.gitVersion=${RELEASE_VER} \
 	-X github.com/portworx/kdmp/pkg/version.gitCommit=${GIT_SHA} \
 	-X github.com/portworx/kdmp/pkg/version.buildDate=${BUILD_DATE}" \
@@ -219,7 +219,7 @@ build-pxc-exporter: gogenerate
 	@echo "Build kdmp"
 	docker run --rm -v $(shell pwd):/go/src/github.com/portworx/kdmp $(DOCK_BUILD_CNT) \
 		/bin/bash -c 'cd /go/src/github.com/portworx/kdmp/cmd/exporter; \
-	go build -ldflags="-s -w \
+	go build -buildvcs=false -ldflags="-s -w \
 	-X github.com/portworx/kdmp/pkg/version.gitVersion=${RELEASE_VER} \
 	-X github.com/portworx/kdmp/pkg/version.gitCommit=${GIT_SHA} \
 	-X github.com/portworx/kdmp/pkg/version.buildDate=${BUILD_DATE}" \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/portworx/kdmp
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aquilax/truncate v1.0.0

--- a/pkg/executor/nfs/nfsrestorevolcreate.go
+++ b/pkg/executor/nfs/nfsrestorevolcreate.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -37,12 +36,6 @@ const (
 	volumeFactor          = 1.5
 	volumeSteps           = 15
 )
-
-var volumeAPICallBackoff = wait.Backoff{
-	Duration: volumeinitialDelay,
-	Factor:   volumeFactor,
-	Steps:    volumeSteps,
-}
 
 func newRestoreVolumeCommand() *cobra.Command {
 	restoreCommand := &cobra.Command{


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
It upgrades go lang version to 1.20.5 from 1.19.0

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PB-4338

**Special notes for your reviewer**:

