### PR TITLE
PB-4446 - Added changes to install kopia from github assets

### DIFF
--- a/Dockerfile.kopia
+++ b/Dockerfile.kopia
@@ -5,11 +5,10 @@ MAINTAINER Portworx Inc. <support@portworx.com>
 RUN microdnf install -y bash vim make wget gpg ca-certificates yum && \
         microdnf clean all
 
-RUN rpm --import https://kopia.io/signing-key
+RUN curl -LJO https://github.com/kopia/kopia/releases/download/v0.10.6/kopia-0.10.6.x86_64.rpm
 
-COPY kopia.repo /etc/yum.repos.d/kopia.repo
+RUN yum install -y kopia-0.10.6.x86_64.rpm
 
-RUN yum install -y kopia-0.10.6
 WORKDIR /
 
 COPY ./bin/kopiaexecutor /

--- a/kopia.repo
+++ b/kopia.repo
@@ -1,6 +1,0 @@
-[Kopia]
-name=Kopia
-baseurl=http://packages.kopia.io/rpm/stable/$basearch/
-gpgcheck=1
-enabled=1
-gpgkey=https://kopia.io/signing-key


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: This PR fixes kopia installation by downloading the setup from github assets rather than from kopia rhel repository 

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PB-4446

**Special notes for your reviewer**:

![Screenshot from 2023-09-20 16-41-16](https://github.com/portworx/kdmp/assets/101168875/feead2ac-2dfc-4d60-b6da-ce6a3589a083)
![Screenshot from 2023-09-20 16-41-29](https://github.com/portworx/kdmp/assets/101168875/19c6fcf0-5dc2-4d9e-b040-0a972ad025cb)


