### PR TITLE
PB-4396 Added code to capture pod's description incase of failure

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -520,6 +520,13 @@ func appendPodLogToStork(jobName string, namespace string) {
 	}
 	for _, pod := range pods.Items {
 		numLogLines := int64(50)
+		podDescribe, err := core.Instance().GetPodByName(pod.Name, pod.Namespace)
+		if err != nil {
+			logrus.Infof("Error fetching description of job-pod[%s] :%v", pod.Name, err)
+		}
+		logrus.Infof("start of job-pod [%s]'s description", pod.Name)
+		logrus.Infof("Describe %v", podDescribe)
+		logrus.Infof("end of job-pod [%s]'s description", pod.Name)
 		podLog, err := core.Instance().GetPodLog(pod.Name, pod.Namespace, &corev1.PodLogOptions{TailLines: &numLogLines})
 		if err != nil {
 			logrus.Infof("error fetching log of job-pod %s: %v", pod.Name, err)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Capture job's and pod's describe output in case of failure.

**Which issue(s) this PR fixes** (optional)
Closes #309 https://portworx.atlassian.net/browse/PB-4396

**Special notes for your reviewer**:

- Added ENABLE_PX_GENERIC_BACKUP: "true" - key-value pair to the data section in kdmp-config file to trigger generic backup with px-vol cluster
- 
![Uploading kdmp-config.png…]()


- Simulated a pod failure by giving wrong command to run inside the container which exits with non-zero status code

- Checked the log for the leader stork pod while triggering a live backup

<img width="1193" alt="POd's description" src="https://github.com/portworx/kdmp/assets/141733960/41418e4c-f8d0-4f97-bbec-dd88e3acb083">
<img width="1169" alt="pod's description 2" src="https://github.com/portworx/kdmp/assets/141733960/58767829-47b3-47dc-8e97-1a10060cf58d">


