### PR TITLE
pb-4579: Passing --sseType to kopia only when S3Config.SseType is passed

### DIFF
--- a/pkg/executor/kopia/kopiabackup.go
+++ b/pkg/executor/kopia/kopiabackup.go
@@ -181,11 +181,11 @@ func populateS3AccessDetails(initCmd *kopia.Command, repository *executor.Reposi
 	initCmd.AddArg(repository.S3Config.AccessKeyID)
 	initCmd.AddArg("--secret-access-key")
 	initCmd.AddArg(repository.S3Config.SecretAccessKey)
-	initCmd.AddArg("--sseType")
 	// At present the backuplocation CR was set with "AES256" value for SSE-S3.
 	// So need to do this conversion.
 	switch repository.S3Config.SseType {
 	case "AES256":
+		initCmd.AddArg("--sseType")
 		initCmd.AddArg("SSE-S3")
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-4579: Passing --sseType to kopia only when S3Config.SseType is passed.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-4579

**Special notes for your reviewer**:
Added minor fix in the kopia source, to make sse-type as optional.
Before Fix:
```
cmd.Flag("sseType", "SSE types, only SSE-S3 is supported.").Required().StringVar(&c.s3options.SseType)
```
After Fix:
```
cmd.Flag("sseType", "SSE types, only SSE-S3 is supported.").Default("").StringVar(&c.s3options.SseType)
```
Will add the test result in the Px-backup PR and will add a reference to it.
https://github.com/portworx/px-backup/pull/1352 - px-backup PR