### PR TITLE
pb-4579: Added check to ignore sseTypePath secret file as it is optional

### DIFF
--- a/pkg/executor/common.go
+++ b/pkg/executor/common.go
@@ -349,9 +349,12 @@ func parseS3Creds() (*Repository, error) {
 
 	sseType, err := os.ReadFile(sseTypePath)
 	if err != nil {
-		errMsg := fmt.Sprintf("failed reading data from file %s : %s", sseTypePath, err)
-		logrus.Errorf("%v", errMsg)
-		return nil, fmt.Errorf(errMsg)
+		// sseTypePath field in the secret is optional, So ignoring if the file does not exists.
+		if !os.IsNotExist(err) {
+			errMsg := fmt.Sprintf("failed reading data from file %s : %s", sseTypePath, err)
+			logrus.Errorf("%v", errMsg)
+			return nil, fmt.Errorf(errMsg)
+		}
 	}
 
 	disableSsl, err := os.ReadFile(disableSslPath)


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-4579: Added check to ignore sseTypePath secret file as it is optional.
```

**Which issue(s) this PR fixes** (optional)
Closes #pb-4579

**Special notes for your reviewer**:
**Testing:**
On the QA cluster valid the deletion and maintenance job works for the backuplocaiton which did not had SseType field.

