### PR TITLE
PB-4606: Check for Storage Class Present in Restore Cluster

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -195,7 +195,7 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 			data := updateDataExportDetail{
 				stage:  kdmpapi.DataExportStageCleanup,
 				status: dataExport.Status.Status,
-				reason: "",
+				reason: dataExport.Status.Reason,
 			}
 			return false, c.updateStatus(dataExport, data)
 		}
@@ -1622,7 +1622,6 @@ func (c *Controller) restoreSnapshot(ctx context.Context, snapshotDriver snapsho
 	if err != nil {
 		return nil, err
 	}
-
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      toSnapshotPVCName(srcPvc.Name, string(de.UID)),


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  To error out proper message when storage class is not present in restore cluster in case of kdmp

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

<img width="1728" alt="Screenshot 2023-10-25 at 4 30 05 PM" src="https://github.com/portworx/kdmp/assets/125460878/40075108-a433-4bd2-81ed-391b4c7362cf">
