### PR TITLE
pb-4969: Fixed issue with backuplocation CR variable, which was causing the nfs backup issue.

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -287,7 +287,7 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 				blNamespace = vb.Spec.BackupLocation.Namespace
 			}
 
-			backupLocation, err := readBackupLocation(blName, blNamespace, "")
+			backupLocation, err = readBackupLocation(blName, blNamespace, "")
 			if err != nil {
 				msg := fmt.Sprintf("reading of backuplocation [%v/%v] failed: %v", blNamespace, blName, err)
 				logrus.Errorf(msg)


### PR DESCRIPTION
**What this PR does / why we need it**:
```
   pb-4969: Fixed issue with backuplocation CR variable, which was causing
    the nfs backup issue.

            - backuplocation CR variable scope was lost inside the if
              condtion. Because of this the nfs parameters are not passed to kopia job.
            - The kopia writes the snapshot file directly  inside the job
              pod file system and files are lost once the pod is completed.
            - Since the nfs parameters are not passed, the nfs pvc was not
              getting mounted inside the nfs job pod.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-4969

**Special notes for your reviewer**:
Testing:
1) Tested both the backup and restore with NFS backuplocation.
