### PR TITLE
updated travis/makefile for 1.2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ script:
   - |
     if [ -n "${TRAVIS_TAG}" ]; then
       export RELEASE_VER=${TRAVIS_TAG}
-    elif [ "${TRAVIS_BRANCH}" == "master" ]; then
-      export DOCKER_IMAGE_TAG=master-latest
+    elif [ "${TRAVIS_BRANCH}" == "1.2.11" ]; then
+      export DOCKER_IMAGE_TAG=1.2.11
     else
       export RELEASE_VER=`git rev-parse --short HEAD`
     fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RELEASE_VER ?= master-latest
+RELEASE_VER ?= 1.2.11
 BUILD_DATE  := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 BASE_DIR    := $(shell git rev-parse --show-toplevel)
 GIT_SHA     := $(shell git rev-parse --short HEAD)
@@ -11,7 +11,7 @@ DOCKER_IMAGE_NAME?=kdmp
 DOCKER_IMAGE_TAG?=$(RELEASE_VER)
 
 DOCKER_KDMP_UNITTEST_IMAGE?=px-kdmp-unittest
-DOCKER_KDMP_TAG?=master-latest
+DOCKER_KDMP_TAG?=1.2.11
 
 DOCKER_IMAGE=$(DOCKER_IMAGE_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
 KDMP_UNITTEST_IMG=$(DOCKER_IMAGE_REPO)/$(DOCKER_KDMP_UNITTEST_IMAGE):$(DOCKER_KDMP_TAG)
@@ -30,7 +30,7 @@ export GOFLAGS = -mod=vendor
 
 MAJOR_VERSION := 1
 MINOR_VERSION := 2
-PATCH_VERSION := 6
+PATCH_VERSION := 11
 
 ifndef PKGS
 	PKGS := $(shell GOFLAGS=-mod=vendor go list ./... 2>&1 | grep -v 'go: ' | grep -v 'github.com/portworx/kdmp/vendor' | grep -v versioned | grep -v 'pkg/apis/v1')

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -24,7 +24,7 @@ const (
 //
 // These variables typically come from -ldflags settings.
 var (
-	gitVersion = "master-latest"
+	gitVersion = "1.2.11"
 	gitCommit  = ""                     // sha1 from git, output of $(git rev-parse HEAD)
 	buildDate  = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 	kbVerRegex = regexp.MustCompile(`^(v\d+\.\d+\.\d+)(.*)`)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Added changes to update master travis to point to 1.2.11 version tag of KDMP. By this way master branch build pushes the image with 1.2.11 tag. During the branch cut of release, master has to be updated with newer version 

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

