### PR TITLE
pb-4943: Added fix to return proper error message, if the kdmp backup fails in DataExportStageTransferInProgress stage.

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -376,13 +376,19 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 		}
 		return true, c.updateStatus(dataExport, data)
 	case kdmpapi.DataExportStageTransferInProgress:
+		var reason string
+		if dataExport.Status.Status == kdmpapi.DataExportStatusSuccessful {
+			reason = ""
+		} else {
+			reason = dataExport.Status.Reason
+		}
 		if dataExport.Status.Status == kdmpapi.DataExportStatusSuccessful ||
 			dataExport.Status.Status == kdmpapi.DataExportStatusFailed {
 			// set to the next stage
 			data := updateDataExportDetail{
 				stage:  kdmpapi.DataExportStageCleanup,
 				status: dataExport.Status.Status,
-				reason: "",
+				reason: reason,
 			}
 			return false, c.updateStatus(dataExport, data)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
```
    pb-4943: Added fix to return proper error message, if the kdmp backup
    fails in DataExportStageTransferInProgress stage.

            - Currently, we are passing empty reason for the failed case, so
              the reason is not passed to the UI. In the failed case, it shows empty reason.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-4943

**Special notes for your reviewer**:
Testing:
1) Created a kdmp backup, when the job is created, Deleted the job pod. 
**Before Fix:**
![Screenshot 2023-12-11 at 6 48 20 PM](https://github.com/portworx/kdmp/assets/52188641/de0db11b-fede-4397-b52a-cf3fbe11e74c)

**After Fix:**
![Screenshot 2023-12-11 at 6 48 28 PM](https://github.com/portworx/kdmp/assets/52188641/bb1a5b6e-8c84-4194-b50f-d1b786940c42)
