### PR TITLE
Add pod events to log incase of job failure

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -626,18 +626,36 @@ func appendPodLogToStork(jobName string, namespace string) {
 		numLogLines := int64(50)
 		podDescribe, err := core.Instance().GetPodByName(pod.Name, pod.Namespace)
 		if err != nil {
-			logrus.Infof("Error fetching description of job-pod[%s] :%v", pod.Name, err)
+			logrus.Infof("error fetching description of job-pod[%s] :%v", pod.Name, err)
 		}
-		logrus.Infof("start of job-pod [%s]'s description", pod.Name)
-		logrus.Infof("Describe %v", podDescribe)
+		logrus.Infof("---")
+		logrus.Infof("pod describe of job [%s/%s] of namespace [%s]", pod.Name, jobName, pod.Namespace)
+		logrus.Infof("---")
+		logrus.Infof("%v", podDescribe)
 		logrus.Infof("end of job-pod [%s]'s description", pod.Name)
+		logrus.Infof("---")
+		logrus.Infof("pod events of  job  [%s/%s] of namespace [%s]", pod.Name, jobName, pod.Namespace)
+		logrus.Infof("---")
+		opts := metav1.ListOptions{
+			FieldSelector: "involvedObject.name=" + pod.Name,
+		}
+		events, err := core.Instance().ListEvents(namespace, opts)
+		if err != nil {
+			logrus.Infof("error to fetch events for pod[%s/%s]: %v", namespace, pod.Name, err)
+		} else {
+			logrus.Infof("%v", events)
+			logrus.Infof("---")
+		}
 		podLog, err := core.Instance().GetPodLog(pod.Name, pod.Namespace, &corev1.PodLogOptions{TailLines: &numLogLines})
 		if err != nil {
 			logrus.Infof("error fetching log of job-pod %s: %v", pod.Name, err)
 		} else {
-			logrus.Infof("start of job-pod [%s]'s log...", pod.Name)
+			logrus.Infof("---")
+			logrus.Infof("pod log of job [%s/%s]", pod.Name, jobName)
+			logrus.Infof("---")
 			logrus.Infof(podLog)
 			logrus.Infof("end of job-pod [%s]'s log...", pod.Name)
+			logrus.Infof("---")
 		}
 	}
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
if a job fails ,events being captured in the job pod are added to logs.

**Which issue(s) this PR fixes** (optional)
Closes #PB-5213

**Special notes for your reviewer**:
Screenshot shows the display of pod events when failure is simulated :
<img width="1654" alt="Screenshot 2023-12-14 at 3 47 45 PM" src="https://github.com/portworx/kdmp/assets/123449175/9f804a76-20a7-479c-8cd5-261c2c00f285">