### PR TITLE
pb-5288: Adding "sidecar.istio.io/injec: false" label to the job pods.

### DIFF
--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -81,6 +81,7 @@ const (
 	NFSExecutorRequestMemory     = "KDMP_NFSEXECUTOR_REQUEST_MEMORY"
 	NFSExecutorLimitCPU          = "KDMP_NFSEXECUTOR_LIMIT_CPU"
 	NFSExecutorLimitMemory       = "KDMP_NFSEXECUTOR_LIMIT_MEMORNFS"
+	KdmpDisableIstioConfig       = "KDMP_DISABLE_ISTIO_CONFIG"
 )
 
 // Default parameters for job options.

--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -457,6 +457,7 @@ func addJobLabels(labels map[string]string) map[string]string {
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.KopiaBackup
+	labels = utils.SetDisableIstioLabel(labels)
 	return labels
 }
 

--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -396,6 +396,7 @@ func addJobLabels(labels map[string]string, jobOpts drivers.JobOpts) map[string]
 	labels[drivers.DriverNameLabel] = drivers.KopiaDelete
 	labels[utils.BackupObjectNameKey] = utils.GetValidLabel(jobOpts.BackupObjectName)
 	labels[utils.BackupObjectUIDKey] = jobOpts.BackupObjectUID
+	labels = utils.SetDisableIstioLabel(labels)
 	return labels
 }
 

--- a/pkg/drivers/kopiamaintenance/kopiamaintenance.go
+++ b/pkg/drivers/kopiamaintenance/kopiamaintenance.go
@@ -435,6 +435,7 @@ func addJobLabels(labels map[string]string) map[string]string {
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.KopiaMaintenance
+	labels = utils.SetDisableIstioLabel(labels)
 	return labels
 }
 

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -356,6 +356,7 @@ func addJobLabels(labels map[string]string) map[string]string {
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.KopiaRestore
+	labels = utils.SetDisableIstioLabel(labels)
 	return labels
 }
 

--- a/pkg/drivers/nfsbackup/nfsbackup.go
+++ b/pkg/drivers/nfsbackup/nfsbackup.go
@@ -172,6 +172,7 @@ func addJobLabels(labels map[string]string) map[string]string {
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.NFSBackup
+	labels = utils.SetDisableIstioLabel(labels)
 	return labels
 }
 

--- a/pkg/drivers/nfscsirestore/nfscsirestore.go
+++ b/pkg/drivers/nfscsirestore/nfscsirestore.go
@@ -174,6 +174,7 @@ func addJobLabels(labels map[string]string) map[string]string {
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.NFSRestore
+	labels = utils.SetDisableIstioLabel(labels)
 	return labels
 }
 

--- a/pkg/drivers/nfsdelete/nfsdelete.go
+++ b/pkg/drivers/nfsdelete/nfsdelete.go
@@ -153,6 +153,7 @@ func addJobLabels(labels map[string]string, jobOpts drivers.JobOpts) map[string]
 	labels[drivers.DriverNameLabel] = drivers.NFSDelete
 	labels[utils.BackupObjectNameKey] = jobOpts.BackupObjectName
 	labels[utils.BackupObjectUIDKey] = jobOpts.BackupObjectUID
+	labels = utils.SetDisableIstioLabel(labels)
 	return labels
 }
 

--- a/pkg/drivers/nfsrestore/nfsrestore.go
+++ b/pkg/drivers/nfsrestore/nfsrestore.go
@@ -171,6 +171,7 @@ func addJobLabels(labels map[string]string) map[string]string {
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.NFSRestore
+	labels = utils.SetDisableIstioLabel(labels)
 	return labels
 }
 

--- a/pkg/drivers/utils/utils.go
+++ b/pkg/drivers/utils/utils.go
@@ -63,6 +63,7 @@ const (
 	PvcBoundSuccessMsg = "pvc bounded successfully"
 	// PvcBoundFailedMsg pvc not bounded msg
 	PvcBoundFailedMsg = "pvc not bounded"
+	IstioInjectLabel  = "sidecar.istio.io/inject"
 )
 
 var (
@@ -875,4 +876,25 @@ func IsJobPodMountFailed(job *batchv1.Job, namespace string) bool {
 		}
 	}
 	return false
+}
+
+func GetDisableIstioConfig() bool {
+	kdmpData, err := core.Instance().GetConfigMap(KdmpConfigmapName, KdmpConfigmapNamespace)
+	if err != nil {
+		logrus.Tracef("error readig kdmp config map: %v", err)
+		return false
+	}
+	if disableIstioConfig, ok := kdmpData.Data[drivers.KdmpDisableIstioConfig]; ok && disableIstioConfig == "true" {
+		return true
+	}
+
+	return false
+}
+
+func SetDisableIstioLabel(labels map[string]string) map[string]string {
+	disableIstioConfig := GetDisableIstioConfig()
+	if disableIstioConfig {
+		labels[IstioInjectLabel] = "false"
+	}
+	return labels
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
```

   pb-5288: Adding "sidecar.istio.io/inject: false" label to the job pods.

            - Currently, with Istio enabled on a namespace, it will create
              istio-proxy container for all the pods. With the job pod, there is a
              known issue where even though the actual job pod container completes,
              the istio-proxy continues to runs.  This makes the job pod to hang.

            - This issue is fixed with k8s 1.28.0 and Istion 1.19.0. Still that point,
              we are providing a option to customer such they can set the
              KDMP_DISABLE_ISTIO_CONFIG to true in the kdmp-confg configmap and we
              will add the "sidecar.istio.io/inject: false" labels to the job pod that
              we create. That way the istio-proxy container will not be added to the job
              pod, even if the Istio is enabled at the namespace.
```

**Which issue(s) this PR fixes** (optional)
Closes # pb-5288

**Special notes for your reviewer**:
**Testing:**
**kdmp-config configmap dump:**
```
[root@ssubramani-18-0 ~]# kubectl get cm kdmp-config -n kube-system -o yaml
apiVersion: v1
data:
  ENABLE_PX_GENERIC_BACKUP: "true" 
  KDMP_BACKUP_JOB_LIMIT: "5"
  KDMP_DELETE_JOB_LIMIT: "5"
  KDMP_DISABLE_ISTIO_CONFIG: "true" <<<<<<<
  KDMP_KOPIAEXECUTOR_IMAGE: kopiaexecutor:1.2.10
  KDMP_KOPIAEXECUTOR_IMAGE_SECRET: ""
  KDMP_KOPIAEXECUTOR_LIMIT_CPU: "0.2"
  KDMP_KOPIAEXECUTOR_LIMIT_MEMORY: 1Gi
  KDMP_KOPIAEXECUTOR_REQUEST_CPU: "0.1"
  KDMP_KOPIAEXECUTOR_REQUEST_MEMORY: 700Mi
  KDMP_MAINTENANCE_JOB_LIMIT: "5"
  KDMP_RESTORE_JOB_LIMIT: "5"
  SNAPSHOT_TIMEOUT: ""
kind: ConfigMap
metadata:
  creationTimestamp: "2024-01-23T15:54:43Z"
  name: kdmp-config
  namespace: kube-system
  resourceVersion: "243871"
  uid: 1a19b33d-980f-4d19-9eed-3f80ac90c3c6
[root@ssubramani-18-0 ~]#
```
**KdmpBackup with S3:**

- You can see that KDMP backup job pod was having only one container. The istio-proxy container was not added as the "sidecar.istio.io/inject=false" label was added to the labels. 

```
[root@ssubramani-18-0 ~]# kubectl  get pods -n mysql
NAME                                 READY   STATUS              RESTARTS   AGE
backup-66635cf-384f065-mysql-j45sp   0/1     ContainerCreating   0          1s
mysql-77ccff5f9c-qgxqh               2/2     Running             0          10h
[root@ssubramani-18-0 ~]# kubectl  describe pods backup-66635cf-384f065-mysql-j45sp -n central
Error from server (NotFound): pods "backup-66635cf-384f065-mysql-j45sp" not found
[root@ssubramani-18-0 ~]# kubectl  describe pods backup-66635cf-384f065-mysql-j45sp -n mysql
Name:             backup-66635cf-384f065-mysql-j45sp
Namespace:        mysql
Priority:         0
Service Account:  backup-66635cf-384f065-mysql
Node:             ssubramani-18-1/10.13.10.142
Start Time:       Wed, 24 Jan 2024 03:50:27 +0000
Labels:           controller-uid=4dc39d61-7371-429b-8c2a-d10518cdaf04
                  job-name=backup-66635cf-384f065-mysql
                  kdmp.portworx.com/applicationbackup-cr-name=test2-dc82614
                  kdmp.portworx.com/applicationbackup-cr-uid=66635cf
                  kdmp.portworx.com/backupobject-name=test2
                  kdmp.portworx.com/backupobject-uid=dc826145-65d7-4bdc-b2a4-d2dad088aa7b
                  kdmp.portworx.com/driver-name=kopiabackup
                  kdmp.portworx.com/pvc-name=mysql-data
                  kdmp.portworx.com/pvc-uid=384f065
                  sidecar.istio.io/inject=false <<<<<<<<
```

**KDMP restore with S3:**

- You can see that KDMP restore job was having only one container. The istio-proxy was not added as the "sidecar.istio.io/inject=false" label was added to the pod labels. 
```
[root@ssubramani-18-0 ~]# kubectl  get pods -A | grep -i restore
mysql-restore1   restore-db8d85e-384f065-mysql-restore1-xxv5p   1/1     Running     0             8s
[root@ssubramani-18-0 ~]# kubectl  describe pods restore-db8d85e-384f065-mysql-restore1-xxv5p -n mysql-restore1
Name:             restore-db8d85e-384f065-mysql-restore1-xxv5p
Namespace:        mysql-restore1
Priority:         0
Service Account:  restore-db8d85e-384f065-mysql-restore1
Node:             ssubramani-18-1/10.13.10.142
Start Time:       Wed, 24 Jan 2024 04:22:24 +0000
Labels:           controller-uid=8425dc81-d158-4b00-979d-d1de5a41647f
                  job-name=restore-db8d85e-384f065-mysql-restore1
                  kdmp.portworx.com/applicationrestore-cr-name=restore1-8635126
                  kdmp.portworx.com/applicationrestore-cr-uid=db8d85e6-535e-4d7d-b1de-db3a9a3a48bc
                  kdmp.portworx.com/driver-name=kopiarestore
                  kdmp.portworx.com/pvc-name=mysql-data
                  kdmp.portworx.com/pvc-uid=384f065f-9094-405d-8ae1-f17c3ce00ccf
                  kdmp.portworx.com/restoreobject-name=
                  kdmp.portworx.com/restoreobject-uid=
                  sidecar.istio.io/inject=false. <<<<<<<<
Annotations:      cni.projectcalico.org/containerID: a4621811ab17e65ffef5fd4e89db18ec6c91ec4904d5f897d59c4c96fd5d2876
                  cni.projectcalico.org/podIP: 10.233.82.226/32
                  cni.projectcalico.org/podIPs: 10.233.82.226/32
Status:           Running
```
**KDMP backup with NFS:**

- You can see that KDMP backup job was having only one container. The istio-proxy was not added as the "sidecar.istio.io/inject=false" label was added to the pod labels. 
```
[root@ssubramani-18-0 ~]# kubectl  get pods -A | grep -i backup
central          nfs-backupsync-79ztw                            0/1     Completed   0             34m
central          nfs-checkbackupfilemissing-tlxc2                0/1     Completed   0             6m46s
central          px-backup-6547756bd-cw95l                       1/1     Running     2 (20h ago)   20h
central          pxc-backup-mongodb-0                            1/1     Running     0             20h
central          pxc-backup-mongodb-1                            1/1     Running     1 (20h ago)   20h
central          pxc-backup-mongodb-2                            1/1     Running     0             20h
mysql            nfs-backup-440815b-mysql-rlk9x                  1/1     Running     0             12s
[root@ssubramani-18-0 ~]# kubectl  describe pods nfs-backup-440815b-mysql-rlk9x -n mysql
Name:             nfs-backup-440815b-mysql-rlk9x
Namespace:        mysql
Priority:         0
Service Account:  nfs-backup-440815b-mysql
Node:             ssubramani-18-1/10.13.10.142
Start Time:       Wed, 24 Jan 2024 13:30:24 +0000
Labels:           controller-uid=f197f81e-2ecd-4dce-b022-a237ec1e7675
                  job-name=nfs-backup-440815b-mysql
                  kdmp.portworx.com/driver-name=nfsbackup
                  sidecar.istio.io/inject=false. <<<<<<<<<<
Annotations:      cni.projectcalico.org/containerID: cb4d4ab47da9678100e03a5bc316b0e1c7c1f1860fde9d838bb846107061a217
                  cni.projectcalico.org/podIP: 10.233.82.254/32
                  cni.projectcalico.org/podIPs: 10.233.82.254/32
Status:           Running
```
**KDMP restore with NFS:**

- You can see that KDMP restore job was having only one container. The istio-proxy was not added as the "sidecar.istio.io/inject=false" label was added to the pod labels. 
```
[root@ssubramani-18-0 ~]# kubectl  get pods -A | grep -i restore
mysql-restore1   mysql-77ccff5f9c-stl5k                          2/2     Running     0             9h
nfs-res1         nfs-restore-pvc-f1dbeb9-nfs-res1-rjk2s          0/1     Completed   0             85s
nfs-res1         nfs-restore-resource-f1dbeb9-nfs-res1-p8fjg     1/1     Running     0             6s
[root@ssubramani-18-0 ~]# kubectl describe pods nfs-restore-resource-f1dbeb9-nfs-res1-p8fjg -n nfs-res1
Name:             nfs-restore-resource-f1dbeb9-nfs-res1-p8fjg
Namespace:        nfs-res1
Priority:         0
Service Account:  nfs-restore-resource-f1dbeb9-nfs-res1
Node:             ssubramani-18-1/10.13.10.142
Start Time:       Wed, 24 Jan 2024 13:39:37 +0000
Labels:           controller-uid=d54c4193-dcfe-462a-8489-c7a1bdfb7890
                  job-name=nfs-restore-resource-f1dbeb9-nfs-res1
                  kdmp.portworx.com/driver-name=nfsrestore
                  sidecar.istio.io/inject=false
Annotations:      cni.projectcalico.org/containerID: 90a1afb392c6fa6b888b51f4f50056c441d463a1d71809ebd1f98d95963d50bb
                  cni.projectcalico.org/podIP:
                  cni.projectcalico.org/podIPs:
Status:           Succeeded
```
```
[root@ssubramani-18-0 ~]# kubectl  get pods -A | grep -i restore
mysql-restore1   mysql-77ccff5f9c-stl5k                          2/2     Running     0             9h
nfs-res1         nfs-restore-pvc-f1dbeb9-nfs-res1-rjk2s          1/1     Running     0             27s
nfs-res1         restore-f1dbeb9-384f065-nfs-res1-zlxkx          1/1     Running     0             10s
[root@ssubramani-18-0 ~]# kubectl describe pods nfs-restore-pvc-f1dbeb9-nfs-res1-rjk2s -n nfs-res1
Name:             nfs-restore-pvc-f1dbeb9-nfs-res1-rjk2s
Namespace:        nfs-res1
Priority:         0
Service Account:  nfs-restore-pvc-f1dbeb9-nfs-res1
Node:             ssubramani-18-1/10.13.10.142
Start Time:       Wed, 24 Jan 2024 13:38:18 +0000
Labels:           controller-uid=bb0e7796-c0e9-49fb-b04c-93e5fe9af89d
                  job-name=nfs-restore-pvc-f1dbeb9-nfs-res1
                  kdmp.portworx.com/driver-name=nfsrestore
                  sidecar.istio.io/inject=false
Annotations:      cni.projectcalico.org/containerID: ad7369fc13a22c2b47d3c49af81aa419d2a87977df4870e55e1b0c73f23d6d9a
                  cni.projectcalico.org/podIP:
                  cni.projectcalico.org/podIPs:
Status:           Succeeded
```