### PR TITLE
pb-5288: Added changes to read the istio disable config from px-backup-config for delete and maintenance apis.

### DIFF
--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -266,7 +266,7 @@ func jobFor(
 ) (*batchv1.Job, error) {
 	backupName := jobName
 
-	labels := addJobLabels(jobOption.Labels)
+	labels := addJobLabels(jobOption)
 
 	cmd := strings.Join([]string{
 		"/kopiaexecutor",
@@ -451,13 +451,14 @@ func toRepoName(pvcName, pvcNamespace string) string {
 	return fmt.Sprintf("%s-%s", pvcNamespace, pvcName)
 }
 
-func addJobLabels(labels map[string]string) map[string]string {
+func addJobLabels(jobOpts drivers.JobOpts) map[string]string {
+	labels := jobOpts.Labels
 	if labels == nil {
 		labels = make(map[string]string)
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.KopiaBackup
-	labels = utils.SetDisableIstioLabel(labels)
+	labels = utils.SetDisableIstioLabel(labels, jobOpts)
 	return labels
 }
 

--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -388,7 +388,8 @@ func addVolumeBackupDeleteLabels(jobOpts drivers.JobOpts) map[string]string {
 	return labels
 }
 
-func addJobLabels(labels map[string]string, jobOpts drivers.JobOpts) map[string]string {
+func addJobLabels(jobOpts drivers.JobOpts) map[string]string {
+	labels := jobOpts.Labels
 	if labels == nil {
 		labels = make(map[string]string)
 	}
@@ -396,7 +397,7 @@ func addJobLabels(labels map[string]string, jobOpts drivers.JobOpts) map[string]
 	labels[drivers.DriverNameLabel] = drivers.KopiaDelete
 	labels[utils.BackupObjectNameKey] = utils.GetValidLabel(jobOpts.BackupObjectName)
 	labels[utils.BackupObjectUIDKey] = jobOpts.BackupObjectUID
-	labels = utils.SetDisableIstioLabel(labels)
+	labels = utils.SetDisableIstioLabel(labels, jobOpts)
 	return labels
 }
 
@@ -406,7 +407,7 @@ func buildJob(jobName string, jobOpts drivers.JobOpts) (*batchv1.Job, error) {
 		return nil, err
 	}
 
-	labels := addJobLabels(jobOpts.Labels, jobOpts)
+	labels := addJobLabels(jobOpts)
 	return jobFor(
 		jobOpts,
 		jobName,

--- a/pkg/drivers/kopiamaintenance/kopiamaintenance.go
+++ b/pkg/drivers/kopiamaintenance/kopiamaintenance.go
@@ -180,7 +180,7 @@ func jobFor(
 	requiresV1 bool,
 ) (interface{}, error) {
 
-	labels := addJobLabels(jobOption.Labels)
+	labels := addJobLabels(jobOption)
 	var successfulJobsHistoryLimit int32 = defaultSuccessfulJobsHistoryLimit
 	var failedJobsHistoryLimit int32 = defaultFailedJobsHistoryLimit
 
@@ -429,13 +429,14 @@ func toJobName(jobName, backupLocation string) string {
 	return fmt.Sprintf("%s-%s", kopiaMaintenanceJobPrefix, backupLocation)
 }
 
-func addJobLabels(labels map[string]string) map[string]string {
+func addJobLabels(jobOpts drivers.JobOpts) map[string]string {
+	labels := jobOpts.Labels
 	if labels == nil {
 		labels = make(map[string]string)
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.KopiaMaintenance
-	labels = utils.SetDisableIstioLabel(labels)
+	labels = utils.SetDisableIstioLabel(labels, jobOpts)
 	return labels
 }
 

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -174,7 +174,7 @@ func jobFor(
 	vb *v1alpha1.VolumeBackup,
 	jobName string,
 ) (*batchv1.Job, error) {
-	labels := addJobLabels(jobOption.Labels)
+	labels := addJobLabels(jobOption)
 
 	resources, err := utils.KopiaResourceRequirements(jobOption.JobConfigMap, jobOption.JobConfigMapNs)
 	if err != nil {
@@ -350,13 +350,14 @@ func jobFor(
 	return job, nil
 }
 
-func addJobLabels(labels map[string]string) map[string]string {
+func addJobLabels(jobOpts drivers.JobOpts) map[string]string {
+	labels := jobOpts.Labels
 	if labels == nil {
 		labels = make(map[string]string)
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.KopiaRestore
-	labels = utils.SetDisableIstioLabel(labels)
+	labels = utils.SetDisableIstioLabel(labels, jobOpts)
 	return labels
 }
 

--- a/pkg/drivers/nfsbackup/nfsbackup.go
+++ b/pkg/drivers/nfsbackup/nfsbackup.go
@@ -166,13 +166,14 @@ func roleFor() *rbacv1.ClusterRole {
 	return role
 }
 
-func addJobLabels(labels map[string]string) map[string]string {
+func addJobLabels(jobOpts drivers.JobOpts) map[string]string {
+	labels := jobOpts.Labels
 	if labels == nil {
 		labels = make(map[string]string)
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.NFSBackup
-	labels = utils.SetDisableIstioLabel(labels)
+	labels = utils.SetDisableIstioLabel(labels, jobOpts)
 	return labels
 }
 
@@ -195,7 +196,7 @@ func jobForBackupResource(
 		jobOption.ResoureBackupNamespace,
 	}, " ")
 
-	labels := addJobLabels(jobOption.Labels)
+	labels := addJobLabels(jobOption)
 
 	nfsExecutorImage, imageRegistrySecret, err := utils.GetExecutorImageAndSecret(drivers.NfsExecutorImage,
 		jobOption.NfsImageExecutorSource,

--- a/pkg/drivers/nfscsirestore/nfscsirestore.go
+++ b/pkg/drivers/nfscsirestore/nfscsirestore.go
@@ -168,13 +168,14 @@ func roleFor() *rbacv1.ClusterRole {
 	return role
 }
 
-func addJobLabels(labels map[string]string) map[string]string {
+func addJobLabels(jobOpts drivers.JobOpts) map[string]string {
+	labels := jobOpts.Labels
 	if labels == nil {
 		labels = make(map[string]string)
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.NFSRestore
-	labels = utils.SetDisableIstioLabel(labels)
+	labels = utils.SetDisableIstioLabel(labels, jobOpts)
 	return labels
 }
 
@@ -194,7 +195,7 @@ func jobForRestoreCSISnapshot(
 		jobOption.Namespace,
 	}, " ")
 
-	labels := addJobLabels(jobOption.Labels)
+	labels := addJobLabels(jobOption)
 	// changing job name to nfcsirestore-backupUID-volumeUID instead of deName for better identification
 	jobName := utils.GetCsiRestoreJobName(drivers.NFSCSIRestore, jobOption.DataExportName)
 	nfsExecutorImage, imageRegistrySecret, err := utils.GetExecutorImageAndSecret(drivers.NfsExecutorImage,

--- a/pkg/drivers/nfsdelete/nfsdelete.go
+++ b/pkg/drivers/nfsdelete/nfsdelete.go
@@ -141,11 +141,12 @@ func buildJob(
 	if err != nil {
 		return nil, err
 	}
-	labels := addJobLabels(jobOptions.Labels, jobOptions)
+	labels := addJobLabels(jobOptions)
 	return jobForDeleteResource(jobOptions, resources, labels)
 }
 
-func addJobLabels(labels map[string]string, jobOpts drivers.JobOpts) map[string]string {
+func addJobLabels(jobOpts drivers.JobOpts) map[string]string {
+	labels := jobOpts.Labels
 	if labels == nil {
 		labels = make(map[string]string)
 	}
@@ -153,7 +154,7 @@ func addJobLabels(labels map[string]string, jobOpts drivers.JobOpts) map[string]
 	labels[drivers.DriverNameLabel] = drivers.NFSDelete
 	labels[utils.BackupObjectNameKey] = jobOpts.BackupObjectName
 	labels[utils.BackupObjectUIDKey] = jobOpts.BackupObjectUID
-	labels = utils.SetDisableIstioLabel(labels)
+	labels = utils.SetDisableIstioLabel(labels, jobOpts)
 	return labels
 }
 

--- a/pkg/drivers/nfsrestore/nfsrestore.go
+++ b/pkg/drivers/nfsrestore/nfsrestore.go
@@ -165,13 +165,14 @@ func roleFor() *rbacv1.ClusterRole {
 	return role
 }
 
-func addJobLabels(labels map[string]string) map[string]string {
+func addJobLabels(jobOpts drivers.JobOpts) map[string]string {
+	labels := jobOpts.Labels
 	if labels == nil {
 		labels = make(map[string]string)
 	}
 
 	labels[drivers.DriverNameLabel] = drivers.NFSRestore
-	labels = utils.SetDisableIstioLabel(labels)
+	labels = utils.SetDisableIstioLabel(labels, jobOpts)
 	return labels
 }
 
@@ -214,7 +215,7 @@ func jobForRestoreResource(
 		jobOption.ResoureBackupNamespace,
 	}, " ")
 
-	labels := addJobLabels(jobOption.Labels)
+	labels := addJobLabels(jobOption)
 
 	nfsExecutorImage, imageRegistrySecret, err := utils.GetExecutorImageAndSecret(drivers.NfsExecutorImage,
 		jobOption.NfsImageExecutorSource,

--- a/pkg/drivers/utils/utils.go
+++ b/pkg/drivers/utils/utils.go
@@ -878,10 +878,10 @@ func IsJobPodMountFailed(job *batchv1.Job, namespace string) bool {
 	return false
 }
 
-func GetDisableIstioConfig() bool {
-	kdmpData, err := core.Instance().GetConfigMap(KdmpConfigmapName, KdmpConfigmapNamespace)
+func GetDisableIstioConfig(jobOpts drivers.JobOpts) bool {
+	kdmpData, err := core.Instance().GetConfigMap(jobOpts.JobConfigMap, jobOpts.JobConfigMapNs)
 	if err != nil {
-		logrus.Tracef("error readig kdmp config map: %v", err)
+		logrus.Tracef("error reading kdmp config map: %v", err)
 		return false
 	}
 	if disableIstioConfig, ok := kdmpData.Data[drivers.KdmpDisableIstioConfig]; ok && disableIstioConfig == "true" {
@@ -891,8 +891,8 @@ func GetDisableIstioConfig() bool {
 	return false
 }
 
-func SetDisableIstioLabel(labels map[string]string) map[string]string {
-	disableIstioConfig := GetDisableIstioConfig()
+func SetDisableIstioLabel(labels map[string]string, jobOpts drivers.JobOpts) map[string]string {
+	disableIstioConfig := GetDisableIstioConfig(jobOpts)
 	if disableIstioConfig {
 		labels[IstioInjectLabel] = "false"
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
```
 pb-5288: Added changes to read the istio disable config from px-backup-config for delete and maintenance apis.
```
**Which issue(s) this PR fixes** (optional)
Closes #pb-5288

**Special notes for your reviewer**:
Will add the test result with px-backup PR.
