### PR TITLE
PB-4572:Added logging of pod describe,events and Jobpod log in job failure scenarios 

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -520,13 +520,12 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 		}
 		// Append the job-pod log to stork's pod log in case of failure
 		// it is best effort approach, hence errors are ignored.
-		if dataExport.Status.Status == kdmpapi.DataExportStatusFailed {
-			if dataExport.Status.TransferID != "" {
-				namespace, name, err := utils.ParseJobID(dataExport.Status.TransferID)
-				if err != nil {
-					logrus.Infof("job-pod name and namespace extraction failed: %v", err)
-				}
-				appendPodLogToStork(name, namespace)
+		if dataExport.Status.Status == kdmpapi.DataExportStatusFailed && dataExport.Status.TransferID != "" {
+			namespace, name, err := utils.ParseJobID(dataExport.Status.TransferID)
+			if err != nil {
+				logrus.Errorf("job name and namespace extraction failed: %v", err)
+			} else {
+				utils.DisplayJobpodLogandEvents(name, namespace)
 			}
 		}
 		cleanupTask := func() (interface{}, bool, error) {

--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -606,41 +606,6 @@ func parseExcludeFileListKey(pvcStorageClass string, excludeFileListValue string
 	return excludeFileList, nil
 }
 
-func appendPodLogToStork(jobName string, namespace string) {
-	// Get job and check whether it has live pod attaced to it
-	job, err := batch.Instance().GetJob(jobName, namespace)
-	if err != nil && !k8sErrors.IsNotFound(err) {
-		logrus.Infof("failed in getting job %v/%v with err: %v", namespace, jobName, err)
-	}
-	pods, err := core.Instance().GetPods(
-		job.Namespace,
-		map[string]string{
-			"job-name": job.Name,
-		},
-	)
-	if err != nil {
-		logrus.Infof("failed in fetching job pods %s/%s: %v", namespace, jobName, err)
-	}
-	for _, pod := range pods.Items {
-		numLogLines := int64(50)
-		podDescribe, err := core.Instance().GetPodByName(pod.Name, pod.Namespace)
-		if err != nil {
-			logrus.Infof("Error fetching description of job-pod[%s] :%v", pod.Name, err)
-		}
-		logrus.Infof("start of job-pod [%s]'s description", pod.Name)
-		logrus.Infof("Describe %v", podDescribe)
-		logrus.Infof("end of job-pod [%s]'s description", pod.Name)
-		podLog, err := core.Instance().GetPodLog(pod.Name, pod.Namespace, &corev1.PodLogOptions{TailLines: &numLogLines})
-		if err != nil {
-			logrus.Infof("error fetching log of job-pod %s: %v", pod.Name, err)
-		} else {
-			logrus.Infof("start of job-pod [%s]'s log...", pod.Name)
-			logrus.Infof(podLog)
-			logrus.Infof("end of job-pod [%s]'s log...", pod.Name)
-		}
-	}
-}
-
 func (c *Controller) createJobCredCertSecrets(
 	dataExport *kdmpapi.DataExport,
 	vb *kdmpapi.VolumeBackup,

--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -211,6 +211,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	// Check whether mount point failure
 	mountFailed := utils.IsJobPodMountFailed(job, namespace)
 	if mountFailed {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg := fmt.Sprintf("job [%v/%v] failed to mount pvc, please check job pod's description for more detail", namespace, name)
 		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
 	}
@@ -224,6 +225,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	jobErr, nodeErr := utils.IsJobOrNodeFailed(job)
 	var errMsg string
 	if jobErr {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg = fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
 		return utils.ToJobStatus(0, errMsg, jobStatus), nil
 	}

--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -159,11 +159,6 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		jobStatus = job.Status.Conditions[0].Type
 
 	}
-	if err != nil {
-		errMsg := fmt.Sprintf("failed to get restart count for job  %s/%s job: %v", namespace, name, err)
-		logrus.Errorf("%s: %v", fn, errMsg)
-		return nil, fmt.Errorf(errMsg)
-	}
 
 	if utils.IsJobFailed(job) {
 		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)

--- a/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/pkg/drivers/kopiadelete/kopiadelete.go
@@ -143,6 +143,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	// Check whether mount point failure
 	mountFailed := utils.IsJobPodMountFailed(job, namespace)
 	if mountFailed {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg := fmt.Sprintf("job [%v/%v] failed to mount pvc, please check job pod's description for more detail", namespace, name)
 		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
 	}
@@ -165,6 +166,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	}
 
 	if utils.IsJobFailed(job) {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg := fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
 		return utils.ToJobStatus(0, errMsg, jobStatus), nil
 	}

--- a/pkg/drivers/kopiamaintenance/kopiamaintenance.go
+++ b/pkg/drivers/kopiamaintenance/kopiamaintenance.go
@@ -154,6 +154,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	}
 
 	if utils.IsJobFailed(job) {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg := fmt.Sprintf("check maintenance [%s/%s] job for details: %s", namespace, name, drivers.ErrJobFailed)
 		return utils.ToJobStatus(0, errMsg, jobStatus), nil
 	}

--- a/pkg/drivers/kopiamaintenance/kopiamaintenance.go
+++ b/pkg/drivers/kopiamaintenance/kopiamaintenance.go
@@ -147,11 +147,6 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		jobStatus = job.Status.Conditions[0].Type
 
 	}
-	if err != nil {
-		errMsg := fmt.Sprintf("failed to get restart count for job  %s/%s job: %v", namespace, name, err)
-		logrus.Errorf("%s: %v", fn, errMsg)
-		return nil, fmt.Errorf(errMsg)
-	}
 
 	if utils.IsJobFailed(job) {
 		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -134,11 +134,6 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		jobStatus = job.Status.Conditions[0].Type
 
 	}
-	if err != nil {
-		errMsg := fmt.Sprintf("failed to get restart count for job  %s/%s job: %v", namespace, name, err)
-		logrus.Errorf("%s: %v", fn, errMsg)
-		return nil, fmt.Errorf(errMsg)
-	}
 
 	if utils.IsJobFailed(job) {
 		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -119,6 +119,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	// Check whether mount point failure
 	mountFailed := utils.IsJobPodMountFailed(job, namespace)
 	if mountFailed {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg := fmt.Sprintf("job [%v/%v] failed to mount pvc, please check job pod's description for more detail", namespace, name)
 		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
 	}
@@ -140,6 +141,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	}
 
 	if utils.IsJobFailed(job) {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg := fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
 		return utils.ToJobStatus(0, errMsg, jobStatus), nil
 	}

--- a/pkg/drivers/nfsbackup/nfsbackup.go
+++ b/pkg/drivers/nfsbackup/nfsbackup.go
@@ -86,6 +86,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	// Check whether mount point failure
 	mountFailed := utils.IsJobPodMountFailed(job, namespace)
 	if mountFailed {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg := fmt.Sprintf("job [%v/%v] failed while mounting NFS mount endpoint", namespace, name)
 		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
 	}
@@ -104,6 +105,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	jobErr, nodeErr := utils.IsJobOrNodeFailed(job)
 	var errMsg string
 	if jobErr {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg = fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
 		return utils.ToJobStatus(0, errMsg, jobStatus), nil
 	}

--- a/pkg/drivers/nfscsirestore/nfscsirestore.go
+++ b/pkg/drivers/nfscsirestore/nfscsirestore.go
@@ -111,10 +111,6 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		return utils.ToJobStatus(0, errMsg, jobStatus), nil
 	}
 
-	if utils.IsJobFailed(job) {
-		errMsg := fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
-		return utils.ToJobStatus(0, errMsg, jobStatus), nil
-	}
 	if utils.IsJobPending(job) {
 		logrus.Warnf("restore job %s is in pending state", job.Name)
 		return utils.ToJobStatus(0, "", jobStatus), nil

--- a/pkg/drivers/nfscsirestore/nfscsirestore.go
+++ b/pkg/drivers/nfscsirestore/nfscsirestore.go
@@ -172,7 +172,7 @@ func addJobLabels(jobOpts drivers.JobOpts) map[string]string {
 		labels = make(map[string]string)
 	}
 
-	labels[drivers.DriverNameLabel] = drivers.NFSRestore
+	labels[drivers.DriverNameLabel] = drivers.NFSCSIRestore
 	labels = utils.SetDisableIstioLabel(labels, jobOpts)
 	return labels
 }

--- a/pkg/drivers/nfscsirestore/nfscsirestore.go
+++ b/pkg/drivers/nfscsirestore/nfscsirestore.go
@@ -83,6 +83,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	// Check for mount point failure
 	mountFailed := utils.IsJobPodMountFailed(job, namespace)
 	if mountFailed {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg := fmt.Sprintf("job [%v/%v] failed while mounting NFS mount endpoint", namespace, name)
 		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
 	}
@@ -101,6 +102,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	jobErr, nodeErr := utils.IsJobOrNodeFailed(job)
 
 	if jobErr {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg = fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
 		return utils.ToJobStatus(0, errMsg, jobStatus), nil
 	}

--- a/pkg/drivers/nfsdelete/nfsdelete.go
+++ b/pkg/drivers/nfsdelete/nfsdelete.go
@@ -109,6 +109,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	// Check for mount point failure
 	mountFailed := utils.IsJobPodMountFailed(job, namespace)
 	if mountFailed {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg := fmt.Sprintf("job [%v/%v] failed while mounting NFS mount endpoint", namespace, name)
 		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
 	}
@@ -125,6 +126,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	}
 
 	if utils.IsJobFailed(job) {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg := fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
 		return utils.ToJobStatus(0, errMsg, jobStatus), nil
 	}

--- a/pkg/drivers/nfsrestore/nfsrestore.go
+++ b/pkg/drivers/nfsrestore/nfsrestore.go
@@ -86,6 +86,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 	// Check for mount point failure
 	mountFailed := utils.IsJobPodMountFailed(job, namespace)
 	if mountFailed {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg := fmt.Sprintf("job [%v/%v] failed while mounting NFS mount endpoint", namespace, name)
 		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
 	}
@@ -104,6 +105,7 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 
 	var errMsg string
 	if jobErr {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
 		errMsg = fmt.Sprintf("check %s/%s job for details: %s", namespace, name, drivers.ErrJobFailed)
 		return utils.ToJobStatus(0, errMsg, jobStatus), nil
 	}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
1.Added utility function to display the job pod log,events and description.
Added the call to the jobStatus function where we check the status of job to print logs in case of failure.

2.Code cleanup: Removed unnecessary *err!=nil* blocks and removed appendPodLogtoStork function 
3.Fix label for NFSCSIrestore job which was pointing to NFSRestore before
**Which issue(s) this PR fixes** (optional)
Closes #PB-4572

**Special notes for your reviewer**:
Screenshots of 
1.kopiabackup driver mountfailed and job failed:
![Screenshot 2024-01-29 at 11 45 52 AM](https://github.com/portworx/kdmp/assets/123449175/710ec692-bdc3-492b-a2a1-e27230daf375)
![Screenshot 2024-01-30 at 11 42 10 AM](https://github.com/portworx/kdmp/assets/123449175/02247231-9c30-4de2-b983-775426232ce7)
2.nfsbackup mount and job failed:
![Screenshot 2024-02-03 at 11 05 17 PM](https://github.com/portworx/kdmp/assets/123449175/2321c655-0566-4466-9a3c-286de5df69dc)
<img width="1728" alt="Screenshot 2024-02-04 at 12 06 27 AM" src="https://github.com/portworx/kdmp/assets/123449175/380a2873-67e0-4696-ac3a-ef79f1d44fb8">
<img width="1728" alt="Screenshot 2024-02-04 at 12 06 40 AM" src="https://github.com/portworx/kdmp/assets/123449175/d952bccd-e131-4e3f-9328-ab8732ffdfa7">
<img width="1728" alt="Screenshot 2024-02-04 at 12 06 48 AM" src="https://github.com/portworx/kdmp/assets/123449175/6eb2e013-1c12-45cd-b6d4-919f75690a87">
kopiarestore mount fail:
![Screenshot 2024-01-29 at 6 21 28 PM](https://github.com/portworx/kdmp/assets/123449175/0a1ff9c1-2a7a-411f-a522-b4e6c827843a)

nfsrestore mount and job fail:
![Screenshot 2024-01-29 at 5 56 20 PM](https://github.com/portworx/kdmp/assets/123449175/3fa6f704-88c9-4fd0-82d2-4bed20a1f9f3)
<img width="1728" alt="Screenshot 2024-02-04 at 9 58 06 PM" src="https://github.com/portworx/kdmp/assets/123449175/825e70ea-c00e-411e-b33b-6ead6fd44a6e">
<img width="1728" alt="Screenshot 2024-02-04 at 9 58 19 PM" src="https://github.com/portworx/kdmp/assets/123449175/e40c437e-fde4-451f-8ade-32bd31f0d76f">
<img width="1728" alt="Screenshot 2024-02-04 at 9 58 38 PM" src="https://github.com/portworx/kdmp/assets/123449175/1d881023-2369-43e0-930b-b62d26165584">
NFSCSIrestore:
![Screenshot 2024-02-05 at 2 14 34 PM](https://github.com/portworx/kdmp/assets/123449175/2954139b-e80d-4c3b-9e6b-2c8332ca9df8)
![Screenshot 2024-02-05 at 3 31 12 PM](https://github.com/portworx/kdmp/assets/123449175/fbf8a251-8f0b-4989-a8fd-6b8c990b3283)


Delete and maintenace related screenshot will be added in the PR for px-backup 


