### PR TITLE
pb-5438: Resetting the pvc.Spec.Selector in the kdmp and csi as it is dynamic provisioning.

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -1737,6 +1737,11 @@ func (c *Controller) restoreSnapshot(ctx context.Context, snapshotDriver snapsho
 
 func (c *Controller) createPVC(dataExport *kdmpapi.DataExport) (*corev1.PersistentVolumeClaim, error) {
 	pvc := dataExport.Status.RestorePVC
+	if pvc.Spec.Selector != nil {
+		// Remove the labelselector, as it is a dynamic provisioning.
+		logrus.Infof("createPVC: dataexport %v/%v pvc.Spec.Selector: %v", dataExport.Name, dataExport.Namespace, pvc.Spec.Selector)
+		pvc.Spec.Selector = nil
+	}
 	newPVC, err := core.Instance().CreatePersistentVolumeClaim(pvc)
 	if err != nil {
 		if k8sErrors.IsAlreadyExists(err) {


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-5438: Resetting the pvc.Spec.Selector in the kdmp and csi as it is dynamic provisioning.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-5438

**Special notes for your reviewer**:
**Note:**
```
One PR will raised in stork code to take care of CSI in the RestoreFromLocalSnapshot function of /pkg/snapshotter/snapshotter_csi.go file.
```
**Testing:**
1) Created a static NFS pv and linked it with the PVC with a label selector:
```
➜  ~ kubectl get pvc -n nfs-test -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"nfs-pvc","namespace":"nfs-test"},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"1Gi"}},"selector":{"matchLabels":{"app":"test"}}}}
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
    creationTimestamp: "2024-02-04T09:03:50Z"
    finalizers:
    - kubernetes.io/pvc-protection
    name: nfs-pvc
    namespace: nfs-test
    resourceVersion: "4267466"
    uid: 2376b597-5648-4792-a1a9-dade13f71876
  spec:
    accessModes:
    - ReadWriteMany
    resources:
      requests:
        storage: 1Gi
    selector:
      matchLabels:
        app: test
    volumeMode: Filesystem
    volumeName: nfs-pv
  status:
    accessModes:
    - ReadWriteMany
    capacity:
      storage: 1Gi
    phase: Bound
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
➜  ~ kubectl get pv nfs-pv  -o yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"PersistentVolume","metadata":{"annotations":{},"labels":{"app":"test"},"name":"nfs-pv"},"spec":{"accessModes":["ReadWriteMany"],"capacity":{"storage":"1Gi"},"nfs":{"path":"/mnt/pvc1","server":"10.13.210.251"}}}
    pv.kubernetes.io/bound-by-controller: "yes"
  creationTimestamp: "2024-02-04T09:00:53Z"
  finalizers:
  - kubernetes.io/pv-protection
  labels:
    app: test
  name: nfs-pv
  resourceVersion: "4267464"
  uid: 6927c09f-919d-40db-9259-8fb59d67cb40
spec:
  accessModes:
  - ReadWriteMany
  capacity:
    storage: 1Gi
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: nfs-pvc
    namespace: nfs-test
    resourceVersion: "4267462"
    uid: 2376b597-5648-4792-a1a9-dade13f71876
  nfs:
    path: /mnt/pvc1
    server: 10.13.210.251
  persistentVolumeReclaimPolicy: Retain
  volumeMode: Filesystem
status:
  phase: Bound
➜  ~
```
With out fix, it failing while restore as restore PVC was struck in "Pending" state"
```
➜  ~ kubectl get pvc -n res2
NAME                               STATUS    VOLUME                            CAPACITY   ACCESS MODES   STORAGECLASS                AGE
nfs-pvc                            Pending                                                               ocs-storagecluster-cephfs   54s
pvc-nfs-restore-pvc-2d532ab-res2   Bound     pv-nfs-restore-pvc-2d532ab-res2   10Gi       RWX                                        88s
➜  ~ kubectl get events -n res2
LAST SEEN   TYPE      REASON                 OBJECT                                   MESSAGE
6s          Normal    ExternalProvisioning   persistentvolumeclaim/nfs-pvc            waiting for a volume to be created, either by external provisioner "openshift-storage.cephfs.csi.ceph.com" or manually created by system administrator
2s          Normal    Provisioning           persistentvolumeclaim/nfs-pvc            External provisioner is provisioning volume for claim "res2/nfs-pvc"
2s          Warning   ProvisioningFailed     persistentvolumeclaim/nfs-pvc            failed to provision volume with StorageClass "ocs-storagecluster-cephfs": claim Selector is not supported
94s         Normal    Scheduled              pod/nfs-restore-pvc-2d532ab-res2-tsccf   Successfully assigned res2/nfs-restore-pvc-2d532ab-res2-tsccf to pwx-ocp-208-237-ggd58-worker-vxjtw
93s         Normal    AddedInterface         pod/nfs-restore-pvc-2d532ab-res2-tsccf   Add eth0 [10.131.1.178/23] from openshift-sdn
93s         Normal    Pulling                pod/nfs-restore-pvc-2d532ab-res2-tsccf   Pulling image "openstorage/nfsexecutor:1.2.10"
88s         Normal    Pulled                 pod/nfs-restore-pvc-2d532ab-res2-tsccf   Successfully pulled image "openstorage/nfsexecutor:1.2.10" in 5.049402435s (5.04941885s including waiting)
88s         Normal    Created                pod/nfs-restore-pvc-2d532ab-res2-tsccf   Created container nfsexecutor
88s         Normal    Started                pod/nfs-restore-pvc-2d532ab-res2-tsccf   Started container nfsexecutor
95s         Normal    SuccessfulCreate       job/nfs-restore-pvc-2d532ab-res2         Created pod: nfs-restore-pvc-2d532ab-res2-tsccf
47s         Normal    Completed              job/nfs-restore-pvc-2d532ab-res2         Job completed
➜  ~
```

With fix, the PVC Is bounded as the label selector is removed:
```
➜  ~ kubectl get pvc -n res1
NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
nfs-pvc   Bound    pvc-33f44822-01d0-4a6e-ac88-719230464d06   1Gi        RWX            ocs-storagecluster-cephfs   88m
➜  ~ kubectl get pvc -n res1 -oyaml
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"nfs-pvc","namespace":"nfs-test"},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"1Gi"}},"selector":{"matchLabels":{"app":"test"}}}}
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      stork.libopenstorage.org/created-by: stork.libopenstorage.org/kdmp
      volume.beta.kubernetes.io/storage-provisioner: openshift-storage.cephfs.csi.ceph.com
      volume.kubernetes.io/storage-provisioner: openshift-storage.cephfs.csi.ceph.com
    creationTimestamp: "2024-02-19T08:31:25Z"
    finalizers:
    - kubernetes.io/pvc-protection
    name: nfs-pvc
    namespace: res1
    resourceVersion: "3049210"
    uid: 33f44822-01d0-4a6e-ac88-719230464d06
  spec:
    accessModes:
    - ReadWriteMany
    resources:
      requests:
        storage: 1Gi
    storageClassName: ocs-storagecluster-cephfs
    volumeMode: Filesystem
    volumeName: pvc-33f44822-01d0-4a6e-ac88-719230464d06
  status:
    accessModes:
    - ReadWriteMany
    capacity:
      storage: 1Gi
    phase: Bound
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
➜  ~

```
