### PR TITLE
added log to identify if it's a resource only backup

### DIFF
--- a/pkg/executor/kopia/maintenance.go
+++ b/pkg/executor/kopia/maintenance.go
@@ -171,6 +171,10 @@ func runMaintenance(maintenanceType string) error {
 		repo.Name = genericBackupDir + "/"
 		bucket = blob.PrefixedBucket(bucket, repo.Name)
 		repoList, err = getRepoList(bucket)
+		if len(repoList) == 0 {
+			logrus.Warnf("Provider is non-nfs, No directory %v exists, verify if it is a resource only backup", repo.Name)
+			return nil
+		}
 		if err != nil {
 			logrus.Errorf("getting repo list failed for bucket [%v]: %v", repo.Path, err)
 			return err


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: It adds logs to identify if it's a resource only backup in case of s3 bl

**Which issue(s) this PR fixes** (optional)
Closes # [PB-5823](https://portworx.atlassian.net/browse/PB-5823)

**Special notes for your reviewer**:
**RCA**-
If we take resource only backup (without any pvc), then we don't create a generic backup dir on the backup location
**TestMaintenanceJobForResourceOnlyBackup** checks for the log in the maintenance pod log to verify if it's a resource only backup
If we don't find any generic backup dir, then we throw this warning "No directory exists, verify if it is a resource only backup"
This log statement is covered in nfs backup flow but not in s3 bl scenario
**ss of quick maintenance pod log**
<img width="1653" alt="Screenshot 2024-03-11 at 10 13 32 AM" src="https://github.com/portworx/kdmp/assets/141733960/ebd526b9-2806-41b5-b3fc-f0d40bb2258c">
<img width="834" alt="Screenshot 2024-03-11 at 11 21 38 AM" src="https://github.com/portworx/kdmp/assets/141733960/12cd2b08-a2f0-4f16-9954-59eab569ab62">



[PB-5823]: https://portworx.atlassian.net/browse/PB-5823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ