### PR TITLE
PWX-36486: Rsync job name to be restricted within max length limit.

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -1862,6 +1862,7 @@ func startTransferJob(
 		return drv.StartJob(
 			drivers.WithSourcePVC(srcPVCName),
 			drivers.WithNamespace(dataExport.Spec.Destination.Namespace),
+			drivers.WithDataExportUID(string(dataExport.UID)),
 			drivers.WithDestinationPVC(dataExport.Spec.Destination.Name),
 			drivers.WithLabels(dataExport.Labels),
 		)

--- a/pkg/drivers/options.go
+++ b/pkg/drivers/options.go
@@ -21,6 +21,7 @@ type JobOpts struct {
 	VolumeBackupDeleteName      string
 	VolumeBackupDeleteNamespace string
 	DataExportName              string
+	DataExportUID               string
 	SnapshotID                  string
 	CredSecretName              string
 	CredSecretNamespace         string
@@ -418,9 +419,20 @@ func WithLabels(l map[string]string) JobOption {
 func WithDataExportName(name string) JobOption {
 	return func(opts *JobOpts) error {
 		if strings.TrimSpace(name) == "" {
-			return fmt.Errorf("dataexport namespace should be set")
+			return fmt.Errorf("dataexport name should be set")
 		}
 		opts.DataExportName = name
+		return nil
+	}
+}
+
+// WithDataExportUID is job parameter
+func WithDataExportUID(uid string) JobOption {
+	return func(opts *JobOpts) error {
+		if strings.TrimSpace(uid) == "" {
+			return fmt.Errorf("dataexport UID should be set")
+		}
+		opts.DataExportUID = uid
 		return nil
 	}
 }

--- a/pkg/drivers/rsync/rsync_test.go
+++ b/pkg/drivers/rsync/rsync_test.go
@@ -1,0 +1,45 @@
+package rsync
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/portworx/kdmp/pkg/drivers/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToJobName(t *testing.T) {
+	id := "1234567890"
+	// uid is a 32 character string
+	uid := "abcdefghijklmnopqrstuvwxyzabcdef"
+
+	expectedJobName := fmt.Sprintf("import-rsync-%s-%s", id, utils.GetShortUID(uid))
+	actualJobName := toJobName(id, uid)
+
+	require.Equal(t, expectedJobName, actualJobName, "unexpected job name")
+
+	// Test when the job name exceeds the maximum length
+	longID := "1234567890123456789012345678901234567890123456789012345678901234567890"
+	expectedJobName = fmt.Sprintf("import-rsync-%s-%s", longID[:41], utils.GetShortUID(uid))
+	actualJobName = toJobName(longID, uid)
+
+	require.Equal(t, expectedJobName, actualJobName, "unexpected job name")
+
+	// Test when the job name exceeds the maximum length and the UID is empty
+	expectedJobName = fmt.Sprintf("import-rsync-%s-%s", longID[:49], "")
+	actualJobName = toJobName(longID, "")
+
+	require.Equal(t, expectedJobName, actualJobName, "unexpected job name")
+
+	// Test when the ID is empty
+	expectedJobName = fmt.Sprintf("import-rsync-%s-%s", "", utils.GetShortUID(uid))
+	actualJobName = toJobName("", uid)
+
+	require.Equal(t, expectedJobName, actualJobName, "unexpected job name")
+
+	// Test when the ID and UID are empty
+	expectedJobName = fmt.Sprintf("import-rsync-%s-%s", "", "")
+	actualJobName = toJobName("", "")
+
+	require.Equal(t, expectedJobName, actualJobName, "unexpected job name")
+}

--- a/pkg/drivers/utils/utils.go
+++ b/pkg/drivers/utils/utils.go
@@ -957,3 +957,10 @@ func SetDisableIstioLabel(labels map[string]string, jobOpts drivers.JobOpts) map
 	}
 	return labels
 }
+
+func GetShortUID(uid string) string {
+	if len(uid) < 8 {
+		return uid
+	}
+	return uid[:8]
+}


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**Unit test result**:
```
➜  go test -v -tags unittest -coverprofile=profile.out -covermode=atomic  github.com/portworx/kdmp/pkg/drivers/rsync

=== RUN   TestToJobName
--- PASS: TestToJobName (0.00s)
PASS
coverage: 8.3% of statements
ok      github.com/portworx/kdmp/pkg/drivers/rsync      1.776s  coverage: 8.3% of statements
```

**What this PR does / why we need it**:
The fix is for making rsync job name within job name limit.
Also added dataexport UID to create new job everytime if dataexport spec gets reapplied with same name.


**Which issue(s) this PR fixes** (optional)
Closes # PWX_36486

**Special notes for your reviewer**:
Test results have been updated in PWX-36486
