### PR TITLE
PB-6351: handling labels validation for dataexport CR for pvc name

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -769,7 +769,7 @@ func (c *Controller) stageSnapshotScheduled(ctx context.Context, dataExport *kdm
 	annotations[backupObjectUIDKey] = backupUID
 	annotations[pvcUIDKey] = pvcUID
 	labels := make(map[string]string)
-	labels[pvcNameKey] = dataExport.Spec.Source.Name
+	labels[pvcNameKey] = utils.GetValidLabel(dataExport.Spec.Source.Name)
 	name, namespace, _, err := snapshotDriver.CreateSnapshot(
 		snapshotter.Name(snapName),
 		snapshotter.PVCName(dataExport.Spec.Source.Name),


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- KDMP backup fails if the pvc names is more than 63 chars, as we use the pvc name as labels in data export CR.
- So, fixed the labels validation for dataexport CR for pvc name

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
<img width="667" alt="Screenshot 2024-03-22 at 3 17 49 PM" src="https://github.com/portworx/kdmp/assets/146064543/7e8a1890-79e1-4fd3-b786-d99ee86a9a20">


