### PR TITLE
PB-6205: Support for NFS related partial backup and restore of those partial backups

### DIFF
--- a/pkg/executor/nfs/nfsbkpresources.go
+++ b/pkg/executor/nfs/nfsbkpresources.go
@@ -35,6 +35,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -318,6 +319,47 @@ func uploadResource(
 			return err
 		}
 	}
+
+	// Let's skip the PV and PVCs which got in failed or skipped state
+	processPartialObjects := make([]runtime.Unstructured, 0)
+	failedVolInfoMap := make(map[string]stork_api.ApplicationBackupStatusType)
+	for _, vol := range backup.Status.Volumes {
+		if vol.Status == stork_api.ApplicationBackupStatusFailed ||
+			vol.Status == stork_api.ApplicationBackupStatusSkip {
+			failedVolInfoMap[vol.Volume] = vol.Status
+		}
+	}
+	// Go through all the objects from the list
+	for _, obj := range allObjects{
+		objectType, err := meta.TypeAccessor(obj)
+		if err != nil {
+			return err
+		}
+		if objectType.GetKind() == "PersistentVolumeClaim" {
+			var pvc v1.PersistentVolumeClaim
+			// Find the matching object - PVC, and if it's state is undesired skip it.
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &pvc); err != nil {
+				return fmt.Errorf("error converting to persistent colume claim: %v", err)
+			}
+			if _, ok := failedVolInfoMap[pvc.Spec.VolumeName]; ok {
+				continue
+			}
+		} else if objectType.GetKind() == "PersistentVolume" {
+			var pv v1.PersistentVolume
+			// Again find persistent volume and check if it is in failed or skipped state. If yes, skip it.
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &pv); err != nil {
+				return fmt.Errorf("error converting to persistent volume: %v", err)
+			}
+			// Check if it already exsists in the map.
+			if _, ok := failedVolInfoMap[pv.Name]; ok {
+				continue
+			}
+		}
+		processPartialObjects = append(processPartialObjects, obj)
+	}
+
+	// Update obj list - allObjects with skipped pv and pvcs
+	allObjects = processPartialObjects
 
 	// TODO: Need to create directory with UID GUID needed
 	// for nfs share

--- a/pkg/executor/nfs/nfsrestorevolcreate.go
+++ b/pkg/executor/nfs/nfsrestorevolcreate.go
@@ -132,7 +132,7 @@ func restoreVolResourcesAndApply(
 		}
 		for _, volumeBackup := range backup.Status.Volumes {
 			driverName := volumeBackup.DriverName
-			if volumeBackup.Namespace != namespace {
+			if volumeBackup.Namespace != namespace || volumeBackup.Status == storkapi.ApplicationBackupStatusFailed || volumeBackup.Status == storkapi.ApplicationBackupStatusSkip {
 				continue
 			}
 			// If a list of resources was specified during restore check if


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR introduces two changes where when the objects are uploaded to NFS location. Now, we check if any of the PV and PVCs have failed and skip those while uploading the `resources.json` file. 
During restore from NFS in case if it is partial backup, we skip the PVCs which were either in `Failed` or `Skipped` state
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Restore is successful when the backup was in partial backup state
![Screenshot 2024-03-29 at 7 21 58 PM](https://github.com/portworx/kdmp/assets/148333439/ad451250-1939-4e56-aa8f-296747598066)

PVC which was in failed state during backup is skipped during restore and the restore status is as successful:
![Screenshot 2024-03-29 at 7 21 48 PM](https://github.com/portworx/kdmp/assets/148333439/e90906ec-97af-424f-a401-defc0ab6952f)

Logs of nfs executor during restore:
![Screenshot 2024-03-29 at 7 20 58 PM](https://github.com/portworx/kdmp/assets/148333439/988fe543-b09c-4a8f-a39b-e22ecc2cd6d1)
![Screenshot 2024-03-29 at 7 21 11 PM](https://github.com/portworx/kdmp/assets/148333439/62b7fe3a-f939-4186-9918-a655b7610215)

As seen below, in the resources.json file, the PVC which was in failed state is not uploaded in the file in the BL
![Screenshot 2024-03-29 at 7 13 06 PM](https://github.com/portworx/kdmp/assets/148333439/c034f8ca-a5ff-478e-9fff-a3c764037026)

