### PR TITLE
PB-6609: PVCs which are skipped are marked as fail in volInfos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7
-	github.com/libopenstorage/stork v1.4.1-0.20240329083942-18c231b89340
+	github.com/libopenstorage/stork v1.4.1-0.20240409133559-12ceeca3f14b
 	github.com/portworx/pxc v0.33.0
 	github.com/portworx/sched-ops v1.20.4-rc1.0.20240227055433-19ad4caac7e9
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -3361,8 +3361,10 @@ github.com/libopenstorage/stork v1.4.1-0.20230502135851-9cacb19e1df5/go.mod h1:R
 github.com/libopenstorage/stork v1.4.1-0.20230519043154-cbc10dffaf19/go.mod h1:Xm4DHoViynFXMQKBXGj3IkA77LY2RBFkNtv6vbo3wNw=
 github.com/libopenstorage/stork v1.4.1-0.20230601053837-5dd68f026569/go.mod h1:+mKPMCPNhS/XOF2RPcNFijkr67CCCWp0o8OXVG6xxAk=
 github.com/libopenstorage/stork v1.4.1-0.20230610103146-72cf75320066/go.mod h1:Yst+fnOYjWk6SA5pXZBKm19wtiinjxQ/vgYTXI3k80Q=
-github.com/libopenstorage/stork v1.4.1-0.20240329083942-18c231b89340 h1:dNgusZz4sSrGMzfyQeJJlk/hO8qgxaBEFkoUAGhvEp8=
-github.com/libopenstorage/stork v1.4.1-0.20240329083942-18c231b89340/go.mod h1:k3KSiL2a2ge/B7Z70QKK6wEnmQJX83bWsN8cMwlVzP8=
+github.com/libopenstorage/stork v1.4.1-0.20240408104107-24148aad0543 h1:cU2Bby94ELaKH1llGHL8AfNcZIaJcKpqOJ3ph2uCOWU=
+github.com/libopenstorage/stork v1.4.1-0.20240408104107-24148aad0543/go.mod h1:k3KSiL2a2ge/B7Z70QKK6wEnmQJX83bWsN8cMwlVzP8=
+github.com/libopenstorage/stork v1.4.1-0.20240409133559-12ceeca3f14b h1:NgZ2YWZV67aSLdLP8Lua5fMhL1etjm4/tVrJw6h5Ce8=
+github.com/libopenstorage/stork v1.4.1-0.20240409133559-12ceeca3f14b/go.mod h1:2MjFeW6zUqD3c85Gl4C5sGYVlz8IHoM9wCQ6uo/BFSE=
 github.com/libopenstorage/systemutils v0.0.0-20160208220149-44ac83be3ce1/go.mod h1:xwNGC7xiz/BQ/wbMkvHujL8Gjgseg+x41xMek7sKRRQ=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=

--- a/pkg/executor/nfs/nfsbkpresources.go
+++ b/pkg/executor/nfs/nfsbkpresources.go
@@ -324,8 +324,7 @@ func uploadResource(
 	processPartialObjects := make([]runtime.Unstructured, 0)
 	failedVolInfoMap := make(map[string]stork_api.ApplicationBackupStatusType)
 	for _, vol := range backup.Status.Volumes {
-		if vol.Status == stork_api.ApplicationBackupStatusFailed ||
-			vol.Status == stork_api.ApplicationBackupStatusSkip {
+		if vol.Status == stork_api.ApplicationBackupStatusFailed {
 			failedVolInfoMap[vol.Volume] = vol.Status
 		}
 	}

--- a/pkg/executor/nfs/nfsrestorevolcreate.go
+++ b/pkg/executor/nfs/nfsrestorevolcreate.go
@@ -132,7 +132,7 @@ func restoreVolResourcesAndApply(
 		}
 		for _, volumeBackup := range backup.Status.Volumes {
 			driverName := volumeBackup.DriverName
-			if volumeBackup.Namespace != namespace || volumeBackup.Status == storkapi.ApplicationBackupStatusFailed || volumeBackup.Status == storkapi.ApplicationBackupStatusSkip {
+			if volumeBackup.Namespace != namespace || volumeBackup.Status == storkapi.ApplicationBackupStatusFailed {
 				continue
 			}
 			// If a list of resources was specified during restore check if

--- a/vendor/github.com/libopenstorage/stork/drivers/volume/csi/csi.go
+++ b/vendor/github.com/libopenstorage/stork/drivers/volume/csi/csi.go
@@ -954,7 +954,7 @@ func (c *csi) CancelBackup(backup *storkapi.ApplicationBackup) error {
 				continue
 			}
 			// In the case of partial success, we don't want to clean up for successful PVC VS and VSC
-			if vInfo.Status == storkapi.ApplicationBackupStatusSuccessful || vInfo.Status == storkapi.ApplicationBackupStatusSkip {
+			if vInfo.Status == storkapi.ApplicationBackupStatusSuccessful {
 				continue
 			}
 			snapshotName := vInfo.BackupID

--- a/vendor/github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -132,7 +132,7 @@ const (
 	// ApplicationBackupStatusSuccessful for when backup has completed successfully
 	ApplicationBackupStatusSuccessful ApplicationBackupStatusType = "Successful"
 	// ApplicationBackupStatusSkip for when backup has been skipped
-	ApplicationBackupStatusSkip ApplicationBackupStatusType = "Skipped"
+	// ApplicationBackupStatusSkip ApplicationBackupStatusType = "Skipped"
 )
 
 // ApplicationBackupStageType is the stage of the backup

--- a/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationbackup.go
@@ -310,7 +310,6 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 					a.execRulesCompleted[string(backup.UID)] = true
 				}
 			}
-
 			canDelete, err := a.deleteBackup(backup)
 			if err != nil {
 				logrus.Errorf("%s: cleanup: %s", reflect.TypeOf(a), err)
@@ -823,12 +822,14 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 					return err
 				}
 				if driverName != "" {
+					logrus.Infof("kartik entering the loop where driver name is being checked %v", driverName)
 					// Check if any  PVC needs to be skipped based on "skip-driver" annotation
 					if driverName == skipDriver {
 						volume, err := core.Instance().GetVolumeForPersistentVolumeClaim(&pvc)
 						if err != nil {
-							return fmt.Errorf("Error getting volume for PVC %v: %v", pvc.Name, err)
+							return fmt.Errorf("error getting volume for PVC %v: %v", pvc.Name, err)
 						}
+						logrus.Infof("kartik the driver name is inside the loop skip: %v", driverName)
 						volumeInfo := &stork_api.ApplicationBackupVolumeInfo{}
 						volumeInfo.PersistentVolumeClaim = pvc.Name
 						volumeInfo.PersistentVolumeClaimUID = string(pvc.UID)
@@ -836,7 +837,7 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 						volumeInfo.StorageClass = k8shelper.GetPersistentVolumeClaimClass(&pvc)
 						volumeInfo.DriverName = driverName
 						volumeInfo.Volume = volume
-						volumeInfo.Reason = "volume skipped from backup"
+						volumeInfo.Reason = "volumes not backed up as backuplocation for kdmp is not healthy"
 						// volumeInfo.Status = stork_api.ApplicationBackupStatusSkip
 						volumeInfo.Status = stork_api.ApplicationBackupStatusFailed
 						skipVolInfo = append(skipVolInfo, volumeInfo)
@@ -1145,8 +1146,15 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 	}
 	// append skipped volumes
 	backup.Status.Volumes = append(backup.Status.Volumes, skipVolInfo...)
+	// add for fail and partial success
+	if len(backup.Status.Volumes) == len(skipVolInfo) {
+		// This case signifies that none of the volumes are successfully backed up
+		// hence marking it as failed
+		partialFailed = true
+	} else {
+		partialSuccess = true
+	}
 	if !partialSuccess && partialFailed {
-
 		// This case signifies that none of the volumes are successfully backed up
 		// hence marking it as failed
 		backup.Status.Stage = stork_api.ApplicationBackupStageFinal
@@ -1939,6 +1947,7 @@ func (a *ApplicationBackupController) backupResources(
 		}
 	}
 	backup.Status.FailedVolCount = len(failedVolInfoMap)
+	isPartialBackup := isPartialBackup(backup)
 	for _, obj := range allObjects {
 		objectType, err := meta.TypeAccessor(obj)
 		if err != nil {
@@ -2159,10 +2168,11 @@ func (a *ApplicationBackupController) backupResources(
 				backup.Status.BackupPath = GetObjectPath(backup)
 				backup.Status.Stage = stork_api.ApplicationBackupStageFinal
 				backup.Status.FinishTimestamp = metav1.Now()
-				if backup.Status.FailedVolCount > 0 {
+				if isPartialBackup {
 					backup.Status.Status = stork_api.ApplicationBackupStatusPartialSuccess
-					backup.Status.Reason = "Volumes and resources were backed up partially"
-				} else {
+					backup.Status.Reason = "Some volumes were backed up"
+				}
+				if backup.Status.FailedVolCount == 0 {
 					backup.Status.Status = stork_api.ApplicationBackupStatusSuccessful
 					backup.Status.Reason = "Volumes and resources were backed up successfully"
 				}
@@ -2204,17 +2214,19 @@ func (a *ApplicationBackupController) backupResources(
 	backup.Status.BackupPath = GetObjectPath(backup)
 	backup.Status.Stage = stork_api.ApplicationBackupStageFinal
 	backup.Status.FinishTimestamp = metav1.Now()
-	if backup.Status.FailedVolCount > 0 {
+	if isPartialBackup {
 		backup.Status.Status = stork_api.ApplicationBackupStatusPartialSuccess
-	} else {
+	}
+	if backup.Status.FailedVolCount == 0 {
 		backup.Status.Status = stork_api.ApplicationBackupStatusSuccessful
 	}
 	if len(backup.Spec.NamespaceSelector) != 0 && len(backup.Spec.Namespaces) == 0 {
 		backup.Status.Reason = fmt.Sprintf("Namespace label selector [%s] did not find any namespaces with selected labels for backup", backup.Spec.NamespaceSelector)
 	} else {
-		if backup.Status.FailedVolCount > 0 {
-			backup.Status.Reason = "Volumes and resources were backed up partially"
-		} else {
+		if isPartialBackup {
+			backup.Status.Reason = "Some volumes were backed up"
+		}
+		if backup.Status.FailedVolCount == 0 {
 			backup.Status.Reason = "Volumes and resources were backed up successfully"
 		}
 	}
@@ -2635,4 +2647,8 @@ func (a *ApplicationBackupController) validateApplicationBackupParameters(backup
 		}
 	}
 	return nil
+}
+
+func isPartialBackup(backup *stork_api.ApplicationBackup) bool {
+	return backup.Status.FailedVolCount > 0 && backup.Status.FailedVolCount < len(backup.Status.Volumes)
 }

--- a/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationbackup.go
@@ -837,7 +837,8 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 						volumeInfo.DriverName = driverName
 						volumeInfo.Volume = volume
 						volumeInfo.Reason = "volume skipped from backup"
-						volumeInfo.Status = stork_api.ApplicationBackupStatusSkip
+						// volumeInfo.Status = stork_api.ApplicationBackupStatusSkip
+						volumeInfo.Status = stork_api.ApplicationBackupStatusFailed
 						skipVolInfo = append(skipVolInfo, volumeInfo)
 						continue
 					}
@@ -1933,8 +1934,7 @@ func (a *ApplicationBackupController) backupResources(
 	processPartialObjects := make([]runtime.Unstructured, 0)
 	failedVolInfoMap := make(map[string]stork_api.ApplicationBackupStatusType)
 	for _, vol := range backup.Status.Volumes {
-		if vol.Status == stork_api.ApplicationBackupStatusFailed ||
-			vol.Status == stork_api.ApplicationBackupStatusSkip {
+		if vol.Status == stork_api.ApplicationBackupStatusFailed {
 			failedVolInfoMap[vol.Volume] = vol.Status
 		}
 	}

--- a/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/vendor/github.com/libopenstorage/stork/pkg/applicationmanager/controllers/applicationrestore.go
@@ -603,7 +603,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 			continue
 		}
 		for _, volumeBackup := range backup.Status.Volumes {
-			if volumeBackup.Namespace != namespace || volumeBackup.Status == storkapi.ApplicationBackupStatusFailed || volumeBackup.Status == storkapi.ApplicationBackupStatusSkip {
+			if volumeBackup.Namespace != namespace || volumeBackup.Status == storkapi.ApplicationBackupStatusFailed {
 				continue
 			}
 			// If a list of resources was specified during restore check if

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -441,7 +441,7 @@ github.com/libopenstorage/openstorage-sdk-clients/sdk/golang
 github.com/libopenstorage/secrets
 github.com/libopenstorage/secrets/aws/credentials
 github.com/libopenstorage/secrets/k8s
-# github.com/libopenstorage/stork v1.4.1-0.20240329083942-18c231b89340
+# github.com/libopenstorage/stork v1.4.1-0.20240409133559-12ceeca3f14b
 ## explicit; go 1.21
 github.com/libopenstorage/stork/drivers
 github.com/libopenstorage/stork/drivers/volume


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We have decided to remove status skipped in volInfos for the volumes which are skipped and rather have status as failed itself for the skipped volumes. So, this PR implements that particular feature
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

Scenario1 : NFS location is in Limited Availability and multi NFS backup is taken - Partial Backup
https://github.com/libopenstorage/stork/assets/148333439/3604eba5-b1fd-429a-84a5-06476c904229

Scenario2: NFS location in limited Availability and only KDMP backups are taken, which are skipped and the backup is in failed state
![Screenshot 2024-04-10 at 12 12 17 PM](https://github.com/libopenstorage/stork/assets/148333439/c7a913ac-8c4e-49cd-b5b4-e4599b74533c)
![Screenshot 2024-04-10 at 12 12 28 PM](https://github.com/libopenstorage/stork/assets/148333439/2d235669-4bd0-43df-adfa-166b8c7598d7)

Scenario 3: Valid NFS location and multi NS backup with KDMP and non-KDMP vols - successful backup
![Screenshot 2024-04-10 at 12 17 11 PM](https://github.com/libopenstorage/stork/assets/148333439/9b675309-e913-4f8c-af4e-ffc94cabd9a9)
![Screenshot 2024-04-10 at 12 17 23 PM](https://github.com/libopenstorage/stork/assets/148333439/3a2a89d2-fa45-4b1f-a8e4-f46a53437dc9)

Scenario 4: Valid NFS location and only KDMP vols - successful backup
![Screenshot 2024-04-10 at 12 18 40 PM](https://github.com/libopenstorage/stork/assets/148333439/1d340fb6-ef0c-4b50-8064-d75689436d50)
![Screenshot 2024-04-10 at 12 18 47 PM](https://github.com/libopenstorage/stork/assets/148333439/76e828f1-36ae-420d-9cd5-49d2e7ba3a19)





