### PR TITLE
PB-6687 :: Placing PX secret in nfsrestore job spec 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /bin
 profile.out
 coverage.txt
+.vscode/
+.idea/

--- a/pkg/executor/nfs/nfsrestorevolcreate.go
+++ b/pkg/executor/nfs/nfsrestorevolcreate.go
@@ -135,6 +135,11 @@ func restoreVolResourcesAndApply(
 			if volumeBackup.Namespace != namespace {
 				continue
 			}
+
+			// TODO: Skip portworx volumes in case of nfsRestore PB:6687
+			if driverName == "pxd" {
+				continue
+			}
 			// If a list of resources was specified during restore check if
 			// this PVC was included
 			info.Name = volumeBackup.PersistentVolumeClaim


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR gets secret env from stork deploy used in nfs restore of secured portworx volumes. The access key retrieved is passed as env variable in nfs restore job to complete nfs restore

**Which issue(s) this PR fixes** (optional)
Closes #PB-6687

**Special notes for your reviewer**:
<img width="1709" alt="image" src="https://github.com/portworx/kdmp/assets/54888022/c0949e25-800a-4aca-a619-7afdcfa7c2f6">
<img width="1716" alt="image" src="https://github.com/portworx/kdmp/assets/54888022/ec36a6ef-0132-42ef-866a-9961a2b69297">

**Test Cases combination performed**:
Backup and restore
1. Portworx (Across Cluster)
2. Portworx + CSI + OFFLOAD ( Across Cluster )
3. Portworx + KDMP ( Across Cluster )
4. Portworx + CSI ( Same Cluster ) ( Retain ) ( Deleted App before Restore )
5. BACKUP_TYPE = Generic