### PR TITLE
Pb-6677: Add storage domain for azure cloud provider

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -2260,6 +2260,7 @@ func createAzureSecret(secretName string, backupLocation *storkapi.BackupLocatio
 	credentialData["path"] = []byte(backupLocation.Location.Path)
 	credentialData["storageaccountname"] = []byte(backupLocation.Location.AzureConfig.StorageAccountName)
 	credentialData["storageaccountkey"] = []byte(backupLocation.Location.AzureConfig.StorageAccountKey)
+	credentialData["environment"] = []byte(backupLocation.Location.AzureConfig.Environment)
 	err := utils.CreateJobSecret(secretName, namespace, credentialData, labels)
 
 	return err


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Based on the azure Env type, it adds the storage domain in the repoCreate and repoConnect Command for azure cloud Provider

**Which issue(s) this PR fixes** (optional)
Closes # [PB-6677](https://purestorage.atlassian.net/browse/PB-6677)

**Special notes for your reviewer**:
**Unit Testing**

- vendored these stork changes to px-backup

- Passed the azure env type to backup location cr from px-backup and took a backup on that bl

- Enabled generic backup
- kopia tries to connect to the repo in case of AZURE_PUBLIC,  this validates the storage Domain
- In case of AZURE_CHINA, kopia tries to create the repo, validated storage domain from the repoCreateCommand

Repo Connect Command (Azure Public)
<img width="1658" alt="Screenshot 2024-04-22 at 3 15 39 PM" src="https://github.com/portworx/kdmp/assets/141733960/d113b64f-2199-4e59-afff-4c85879ef0e0">

Repo Create Command (Azure China)
<img width="828" alt="Screenshot 2024-04-22 at 3 50 35 PM" src="https://github.com/portworx/kdmp/assets/141733960/b2bea49d-63ca-4fba-a108-8964eafdcaed">

Repo Creation failed in case of Azure China since we don't have the credential
<img width="1654" alt="Screenshot 2024-04-22 at 3 22 40 PM" src="https://github.com/portworx/kdmp/assets/141733960/5c3cce0f-6dc2-4ecc-8520-5a61213e034e">


[PB-6677]: https://purestorage.atlassian.net/browse/PB-6677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Azure-China Backup
<img width="1482" alt="Screenshot 2024-05-03 at 11 22 41 AM" src="https://github.com/portworx/kdmp/assets/141733960/9a8e6b3c-d954-41af-a0e8-0e419ba5763b">
<img width="1698" alt="Screenshot 2024-05-03 at 11 26 48 AM" src="https://github.com/portworx/kdmp/assets/141733960/528c38f9-9ee8-42e3-ac44-efa771549cec">
