### PR TITLE
PB-6880: Fixed repository file path for deletion 

### DIFF
--- a/pkg/executor/kopia/kopiadelete.go
+++ b/pkg/executor/kopia/kopiadelete.go
@@ -38,8 +38,7 @@ func newDeleteCommand() *cobra.Command {
 }
 
 func isNfsKopiaRepositoryFileExists(repo *executor.Repository) bool {
-	repoBaseDir := repo.Path + genericBackupDir + "/"
-	kopiaRepoFile := filepath.Join(repoBaseDir, repo.Name, kopiaNFSRepositoryFile)
+	kopiaRepoFile := filepath.Join(repo.Path, repo.Name, kopiaNFSRepositoryFile)
 	_, err := os.Stat(kopiaRepoFile)
 	if err != nil && os.IsNotExist(err) {
 		logrus.Debugf("kopia repository file %v does not exist", kopiaRepoFile)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Fixed repository file path for deletion 

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PB-6880

**Special notes for your reviewer**:

![Screenshot from 2024-05-02 18-31-35](https://github.com/portworx/kdmp/assets/101168875/a6000432-48ea-478a-8571-1cbc217b2dc3)


