### PR TITLE
pb-6681: Add support for PSA in kdmp job

### DIFF
--- a/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/pkg/drivers/kopiabackup/kopiabackup.go
@@ -18,6 +18,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 var backupJobLock sync.Mutex
@@ -318,6 +319,10 @@ func jobFor(
 		logrus.Errorf("failed to get the toleration details: %v", err)
 		return nil, fmt.Errorf("failed to get the toleration details for job [%s/%s]", jobOption.Namespace, jobName)
 	}
+	podUserId, podGroupId, err := utils.GetPsaEnabledAppUID(jobOption.SourcePVCName, jobOption.Namespace)
+	if err != nil {
+		logrus.Errorf("failed to get the UID and GID for pvc %s %v", jobOption.SourcePVCName, err)
+	}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -359,6 +364,18 @@ func jobFor(
 									ReadOnly:  true,
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot:             pointer.Bool(true),
+								AllowPrivilegeEscalation: pointer.Bool(false),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: "RuntimeDefault",
+								},
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{
+										"ALL",
+									},
+								},
+							},
 						},
 					},
 					Tolerations: tolerations,
@@ -383,6 +400,15 @@ func jobFor(
 				},
 			},
 		},
+	}
+
+	if job.Spec.Template.Spec.SecurityContext != nil {
+		if podUserId != utils.UndefinedId {
+			job.Spec.Template.Spec.SecurityContext.RunAsUser = &podUserId
+		}
+		if podGroupId != utils.UndefinedId {
+			job.Spec.Template.Spec.SecurityContext.RunAsGroup = &podGroupId
+		}
 	}
 
 	if len(nodeName) != 0 {


### PR DESCRIPTION
- Added check and collected psa info from the namespace
- if psa enabled then extracted the uid and gid used by the POD. here the pod is choosen based on whichever PVC is used by that pod
- applied those uid and GID to all relevant job pod spec
- this is done only if the PSA mode enforced with "restricted" value
- for baseline and privilege mode no restriction on UID/GID and default setting of SElinux and secomp is adopted in the POD spec

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: this adds the PSA feature to px-backup

**Which issue(s) this PR fixes** (optional)
Closes # pb-6681

**Special notes for your reviewer**:
Currently Unit testing, this is a PR to get hold of the code review earlier.
Known Issue : restore path doesn't have a deployment to capture UID and GID, we will use the backupInfo artifacts in mongo to provide that. we should have captured it during backup time.
