### PR TITLE
PB-6853: travis changes to push docker images for private branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
     elif [ "${TRAVIS_BRANCH}" == "master" ]; then
       export DOCKER_IMAGE_TAG=master-latest
     else
-      export RELEASE_VER=`git rev-parse --short HEAD`
+      export DOCKER_IMAGE_TAG=${TRAVIS_BRANCH}
     fi
     make all &&
     if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Travis changes to push the docker images for private branches with branch name as tag.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

<img width="1504" alt="Screenshot 2024-05-14 at 11 24 31 AM" src="https://github.com/portworx/kdmp/assets/146064543/114b5c14-83c3-46be-a82f-13b8941eb848">
<img width="1377" alt="Screenshot 2024-05-14 at 11 23 45 AM" src="https://github.com/portworx/kdmp/assets/146064543/56a364ff-098c-4519-823b-c8bd909c996e">
