### PR TITLE
PB-7300: upgrading packages to fix critical cve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   global:
     - GO111MODULE=on
 go:
-  - 1.21.6
+  - 1.21.11
 script:
   - |
     if [ -n "${TRAVIS_TAG}" ]; then

--- a/Dockerfile.unittest
+++ b/Dockerfile.unittest
@@ -7,8 +7,8 @@ RUN yum -y install gzip git tar wget curl bash vim make gpg bzip2
 
 RUN git config --global --add safe.directory /go/src/github.com/portworx/kdmp
 
-RUN curl https://dl.google.com/go/go1.21.6.linux-amd64.tar.gz -o go1.21.6.linux-amd64.tar.gz
-RUN tar -xf go1.21.6.linux-amd64.tar.gz && mv go /usr/local/
+RUN curl https://dl.google.com/go/go1.21.11.linux-amd64.tar.gz -o go1.21.11.linux-amd64.tar.gz
+RUN tar -xf go1.21.11.linux-amd64.tar.gz && mv go /usr/local/
 ENV GOROOT /usr/local/go
 ENV PATH ${GOPATH}/bin:${GOROOT}/bin:${PATH}
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BASE_DIR    := $(shell git rev-parse --show-toplevel)
 GIT_SHA     := $(shell git rev-parse --short HEAD)
 BIN         := $(BASE_DIR)/bin
 
-DOCK_BUILD_CNT  := golang:1.21.6
+DOCK_BUILD_CNT  := golang:1.21.11
 
 DOCKER_IMAGE_REPO?=portworx
 DOCKER_IMAGE_NAME?=kdmp


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Upgrading golang package 1.21.6 -> 1.21.11 to fix critical cve in nfsexecutor
Not fixing the kopia executor vulnerability as we need to update the kopia binary to 0.17.0 and it requires lot of changes and testing to make sure nothing is breaking.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

![Screenshot 2024-07-02 at 12 10 14 PM](https://github.com/portworx/kdmp/assets/146064543/616f6a49-45f5-460e-9df3-3f069ac96ac4)


