### PR TITLE
PB-7158, PB-7159: Fix Handling of Cloud Based CSI Backups - NFS Location

### DIFF
--- a/pkg/executor/nfs/nfsrestoreresources.go
+++ b/pkg/executor/nfs/nfsrestoreresources.go
@@ -383,13 +383,19 @@ func getPVCToPVMapping(allObjects []runtime.Unstructured) (map[string]*v1.Persis
 	return pvcNameToPV, nil
 }
 
-func isGenericCSIPersistentVolume(pv *v1.PersistentVolume) (bool, error) {
+func isGenericCSIPersistentVolume(pv *v1.PersistentVolume, volInfos []*storkapi.ApplicationRestoreVolumeInfo) (bool, error) {
 	driverName, err := volume.GetPVDriverForRestore(pv)
 	if err != nil {
 		return false, err
 	}
 	if driverName == "csi" {
 		return true, nil
+	}
+	// in case of cloud disk such as GCE, AWS, Azure, we need to skip the volumes as its now moved to csi
+	for _, vInfo := range volInfos {
+		if vInfo.RestoreVolume == pv.Name && vInfo.DriverName == "csi" {
+			return true, nil
+		}
 	}
 	return false, nil
 }
@@ -436,7 +442,7 @@ func removeCSIVolumesBeforeApply(
 			}
 
 			// Check if this PV is a generic CSI one
-			isGenericCSIPVC, err := isGenericCSIPersistentVolume(&pv)
+			isGenericCSIPVC, err := isGenericCSIPersistentVolume(&pv, restore.Status.Volumes)
 			if err != nil {
 				return nil, fmt.Errorf("failed to check if PV was provisioned by a CSI driver: %v", err)
 			}
@@ -468,7 +474,7 @@ func removeCSIVolumesBeforeApply(
 
 			// We have found a PV for this PVC. Check if it is a generic CSI PV
 			// that we do not already have native volume driver support for.
-			isGenericCSIPVC, err := isGenericCSIPersistentVolume(pv)
+			isGenericCSIPVC, err := isGenericCSIPersistentVolume(pv, restore.Status.Volumes)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: When taking Cloud Based CSI Backup such azure, gce, aws the csi based backup in case of replcace in default restore was going in pending state upon find the root cause the removeCSIVolumeBeforeApply was replacing the csi based pvc to default way. 


**Does this PR change a user-facing CRD or CLI?**:
<!-- No
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!-- no
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

ApplicationBackup

```
apiVersion: stork.libopenstorage.org/v1alpha1
kind: ApplicationBackup
metadata:
  annotations:
    portworx.io/backup-name: bbbb
    portworx.io/backup-uid: 9d6cedb4-60de-49e2-b4c0-c67d8d4a4eda
    portworx.io/backuplocation-name: azure-blob
    portworx.io/cluster-name: pb7159
    portworx.io/cluster-uid: 1320d4c6-d045-47ba-8bfa-4dd422c5b446
    portworx.io/created-by: px-backup
    portworx.io/last-update: "2024-06-04T04:00:27.42125951Z"
    portworx.io/object-lock-retention-period: "0"
    portworx.io/org-id: default
    portworx.io/skip-backup-location-name-check: "true"
  creationTimestamp: "2024-06-04T04:00:27Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2024-06-04T04:00:50Z"
  finalizers:
  - stork.libopenstorage.org/finalizer-cleanup
  generation: 12
  name: bbbb-9d6cedb
  namespace: mysql
  resourceVersion: "477814"
  uid: 75bd2dde-d765-433a-978d-8115f18ccd3f
spec:
  backupLocation: azure-blob-9d6cedb
  backupObjectType: All
  backupType: Normal
  csiSnapshotClassMap:
    disk.csi.azure.com: csi-azuredisk-vsc
  directKDMP: false
  includeResources: null
  namespaceSelector: ""
  namespaces:
  - mysql
  options: {}
  platformCredential: ""
  postExecRule: ""
  preExecRule: ""
  rancherProjects: null
  reclaimPolicy: Retain
  resourceTypes: null
  selectors: null
  skipAutoExecRules: false
  skipServiceUpdate: false
status:
  backupPath: mysql/bbbb-9d6cedb/75bd2dde-d765-433a-978d-8115f18ccd3f
  finishTimestamp: "2024-06-04T04:00:50Z"
  largeResourceEnabled: false
  lastUpdateTimestamp: "2024-06-04T04:00:50Z"
  reason: Volumes and resources were backed up successfully
  resourceCount: 11
  resources:
  - group: core
    kind: ServiceAccount
    name: mysql
    namespace: mysql
    version: v1
  - group: core
    kind: Service
    name: mysql
    namespace: mysql
    version: v1
  - group: core
    kind: Service
    name: mysql-headless
    namespace: mysql
    version: v1
  - group: core
    kind: Secret
    name: mysql
    namespace: mysql
    version: v1
  - group: core
    kind: Secret
    name: sh.helm.release.v1.mysql.v1
    namespace: mysql
    version: v1
  - group: core
    kind: ConfigMap
    name: mysql
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: data-mysql-0
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-6ac92c91-09ce-4e4e-92f7-96f911f43ff2
    namespace: ""
    version: v1
  - group: apps
    kind: StatefulSet
    name: mysql
    namespace: mysql
    version: v1
  - group: networking.k8s.io
    kind: NetworkPolicy
    name: mysql
    namespace: mysql
    version: v1
  - group: policy
    kind: PodDisruptionBudget
    name: mysql
    namespace: mysql
    version: v1
  stage: Final
  status: Successful
  totalSize: 8589934592
  triggerTimestamp: "2024-06-04T04:00:27Z"
  volumes:
  - Options:
      csi-driver-name: disk.csi.azure.com
      volumesnapshotcontent-name: snapcontent-22905daf-4877-4e57-9d07-b35be0aa778f
    VolumeJobSecurityContext:
      runAsGroup: 0
      runAsUser: 0
    actualSize: 8589934592
    backupID: backup-8115f18ccd3f-96f911f43ff2
    driverName: csi
    namespace: mysql
    persistentVolumeClaim: data-mysql-0
    persistentVolumeClaimUID: 6ac92c91-09ce-4e4e-92f7-96f911f43ff2
    provisioner: ""
    reason: Snapshot successful for volume
    status: Successful
    storageClass: ""
    totalSize: 8589934592
    volume: pvc-6ac92c91-09ce-4e4e-92f7-96f911f43ff2
    volumeSnapshot: ""
    zones: null
```

ApplicationRestore

```
apiVersion: stork.libopenstorage.org/v1alpha1
kind: ApplicationRestore
metadata:
  annotations:
    portworx.io/cluster-name: pb7159
    portworx.io/cluster-uid: 1320d4c6-d045-47ba-8bfa-4dd422c5b446
    portworx.io/created-by: px-backup
    portworx.io/last-update: "2024-06-04T04:11:52.408617217Z"
    portworx.io/org-id: default
    portworx.io/restore-name: rrr
    portworx.io/restore-uid: 069750b8-875e-4f74-a647-464682dc85f1
  creationTimestamp: "2024-06-04T04:11:52Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2024-06-04T04:12:47Z"
  finalizers:
  - stork.libopenstorage.org/finalizer-cleanup
  generation: 18
  name: rrr-069750b
  namespace: mysql
  resourceVersion: "482252"
  uid: db59dd3c-06ac-4dbf-b816-daa06171047b
spec:
  backupLocation: azure-blob-069750b
  backupName: bbbb-069750b
  backupObjectType: All
  includeOptionalResourceTypes: null
  includeResources: null
  namespaceMapping:
    mysql: mysql
  rancherProjectMapping: null
  replacePolicy: Delete
  storageClassMapping: null
status:
  finishTimestamp: "2024-06-04T04:12:47Z"
  largeResourceEnabled: false
  lastUpdateTimestamp: "2024-06-04T04:12:47Z"
  reason: Volumes and resources were restored up successfully
  resourceCount: 11
  resourcerestorestate: ""
  resources:
  - group: ""
    kind: Secret
    name: mysql
    namespace: mysql
    reason: Resource restored successfully
    status: Successful
    version: v1
  - group: ""
    kind: Secret
    name: sh.helm.release.v1.mysql.v1
    namespace: mysql
    reason: Resource restored successfully
    status: Successful
    version: v1
  - group: ""
    kind: ConfigMap
    name: mysql
    namespace: mysql
    reason: Resource restored successfully
    status: Successful
    version: v1
  - group: ""
    kind: ServiceAccount
    name: mysql
    namespace: mysql
    reason: Resource restored successfully
    status: Successful
    version: v1
  - group: ""
    kind: Service
    name: mysql
    namespace: mysql
    reason: Resource restored successfully
    status: Successful
    version: v1
  - group: ""
    kind: Service
    name: mysql-headless
    namespace: mysql
    reason: Resource restored successfully
    status: Successful
    version: v1
  - group: apps
    kind: StatefulSet
    name: mysql
    namespace: mysql
    reason: Resource restored successfully
    status: Successful
    version: v1
  - group: networking.k8s.io
    kind: NetworkPolicy
    name: mysql
    namespace: mysql
    reason: Resource restored successfully
    status: Successful
    version: v1
  - group: policy
    kind: PodDisruptionBudget
    name: mysql
    namespace: mysql
    reason: Resource restored successfully
    status: Successful
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-69c2b72f-514c-4fbc-86dd-a84c622b3f7e
    namespace: ""
    reason: Resource restored successfully
    status: Successful
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: data-mysql-0
    namespace: mysql
    reason: Resource restored successfully
    status: Successful
    version: v1
  restoredresourceCount: 11
  stage: Final
  status: Successful
  totalSize: 8589934592
  volumes:
  - driverName: csi
    options: null
    persistentVolumeClaim: data-mysql-0
    persistentVolumeClaimUID: 69c2b72f-514c-4fbc-86dd-a84c622b3f7e
    reason: 'Volume restore successful: PVC data-mysql-0 is bound'
    restoreVolume: pvc-69c2b72f-514c-4fbc-86dd-a84c622b3f7e
    sourceNamespace: mysql
    sourceVolume: pvc-6ac92c91-09ce-4e4e-92f7-96f911f43ff2
    status: Successful
    totalSize: 8589934592
    zones: null
```

Final Restored PVC

```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-provisioner: disk.csi.azure.com
    volume.kubernetes.io/selected-node: aks-userpool-60548267-vmss000000
    volume.kubernetes.io/storage-provisioner: disk.csi.azure.com
  creationTimestamp: "2024-06-04T04:12:09Z"
  finalizers:
  - kubernetes.io/pvc-protection
  labels:
    app.kubernetes.io/component: primary
    app.kubernetes.io/instance: mysql
    app.kubernetes.io/name: mysql
  name: data-mysql-0
  namespace: mysql
  resourceVersion: "482129"
  uid: 69c2b72f-514c-4fbc-86dd-a84c622b3f7e
spec:
  accessModes:
  - ReadWriteOnce
  dataSource:
    apiGroup: snapshot.storage.k8s.io
    kind: VolumeSnapshot
    name: restore-vs-daa06171047b-b35be0aa778f
  dataSourceRef:
    apiGroup: snapshot.storage.k8s.io
    kind: VolumeSnapshot
    name: restore-vs-daa06171047b-b35be0aa778f
  resources:
    requests:
      storage: 8Gi
  storageClassName: managed-csi
  volumeMode: Filesystem
  volumeName: pvc-69c2b72f-514c-4fbc-86dd-a84c622b3f7e
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 8Gi
  phase: Bound
```

Final Count 
<img width="1721" alt="Screenshot 2024-06-04 at 10 25 43 AM" src="https://github.com/libopenstorage/stork/assets/125460878/54fccafa-8bc7-4434-9697-de12a5922188">

