### PR TITLE
PB-7476: Adding node affinity to kopia backup and restore jobs

### DIFF
--- a/pkg/controllers/dataexport/reconcile.go
+++ b/pkg/controllers/dataexport/reconcile.go
@@ -1903,6 +1903,11 @@ func startTransferJob(
 		psaJobUid = getAnnotationValue(dataExport, utils.PsaUIDKey)
 		psaJobGid = getAnnotationValue(dataExport, utils.PsaGIDKey)
 	}
+	nodeLabel, err := utils.GetNodeLabelFromDeployment(jobConfigMap, jobConfigMapNs, drivers.PxbJobNodeLabelKey)
+	if err != nil {
+		return "", err
+	}
+
 	switch drv.Name() {
 	case drivers.Rsync:
 		return drv.StartJob(
@@ -1947,6 +1952,7 @@ func startTransferJob(
 			drivers.WithExcludeFileList(excludeFileList),
 			drivers.WithPodDatapathType(podDataPath),
 			drivers.WithJobConfigMap(jobConfigMap),
+			drivers.WithNodeAffinity(nodeLabel),
 			drivers.WithJobConfigMapNs(jobConfigMapNs),
 			drivers.WithNfsServer(nfsServerAddr),
 			drivers.WithNfsExportDir(nfsExportPath),
@@ -1969,6 +1975,7 @@ func startTransferJob(
 			drivers.WithCertSecretNamespace(dataExport.Spec.Destination.Namespace),
 			drivers.WithJobConfigMap(jobConfigMap),
 			drivers.WithJobConfigMapNs(jobConfigMapNs),
+			drivers.WithNodeAffinity(nodeLabel),
 			drivers.WithNfsServer(nfsServerAddr),
 			drivers.WithNfsExportDir(nfsExportPath),
 			drivers.WithPodUserId(psaJobUid),
@@ -2396,6 +2403,11 @@ func startNfsCSIRestoreVolumeJob(
 		logrus.Errorf("failed to create NFS cred secret: %v", err)
 		return "", fmt.Errorf("failed to create NFS cred secret: %v", err)
 	}
+	nodeLabel, err := utils.GetNodeLabelFromDeployment(jobConfigMap, jobConfigMapNs, drivers.PxbJobNodeLabelKey)
+	if err != nil {
+		return "", err
+	}
+
 	switch drv.Name() {
 	case drivers.NFSCSIRestore:
 		return drv.StartJob(
@@ -2410,6 +2422,7 @@ func startNfsCSIRestoreVolumeJob(
 			drivers.WithNfsSubPath(bl.Location.Path),
 			drivers.WithPodUserId(psaJobUid),
 			drivers.WithPodGroupId(psaJobGid),
+			drivers.WithNodeAffinity(nodeLabel),
 		)
 	}
 	return "", fmt.Errorf("unknown driver for nfs csi volume restore: %s", drv.Name())

--- a/pkg/controllers/resourceexport/reconcile.go
+++ b/pkg/controllers/resourceexport/reconcile.go
@@ -412,6 +412,12 @@ func startNfsResourceJob(
 		logrus.Errorf("failed to create NFS cred secret: %v", err)
 		return "", fmt.Errorf("failed to create NFS cred secret: %v", err)
 	}
+
+	nodeLabel, err := utils.GetNodeLabelFromDeployment(jobConfigMap, jobConfigMapNs, drivers.PxbJobNodeLabelKey)
+	if err != nil {
+		return "", err
+	}
+
 	switch drv.Name() {
 	case drivers.NFSBackup:
 		return drv.StartJob(
@@ -427,6 +433,7 @@ func startNfsResourceJob(
 			drivers.WithAppCRNamespace(re.Spec.Source.Namespace),
 			drivers.WithNamespace(re.Namespace),
 			drivers.WithResoureBackupName(re.Name),
+			drivers.WithNodeAffinity(nodeLabel),
 			drivers.WithResoureBackupNamespace(re.Namespace),
 			drivers.WithNfsMountOption(bl.Location.NFSConfig.MountOptions),
 			drivers.WithNfsExportDir(bl.Location.NFSConfig.SubPath),
@@ -445,6 +452,7 @@ func startNfsResourceJob(
 			drivers.WithAppCRNamespace(re.Spec.Source.Namespace),
 			drivers.WithNamespace(re.Namespace),
 			drivers.WithResoureBackupName(re.Name),
+			drivers.WithNodeAffinity(nodeLabel),
 			drivers.WithResoureBackupNamespace(re.Namespace),
 			drivers.WithNfsMountOption(bl.Location.NFSConfig.MountOptions),
 			drivers.WithNfsExportDir(bl.Location.NFSConfig.SubPath),

--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -123,7 +123,8 @@ const (
 
 var (
 	// ErrJobFailed is a know error for a data transfer job failure.
-	ErrJobFailed = fmt.Errorf("data transfer job failed")
+	ErrJobFailed       = fmt.Errorf("data transfer job failed")
+	PxbJobNodeLabelKey = "PXB_JOB_NODE_AFFINITY_LABEL"
 )
 
 // Interface defines a data export driver behaviour.

--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -307,6 +307,12 @@ func jobFor(
 		job.Spec.Template.Spec.ImagePullSecrets = utils.ToImagePullSecret(utils.GetImageSecretName(jobName))
 	}
 
+	// Add node affinity to the job spec
+	job, err = utils.AddNodeAffinityToJob(job, jobOption)
+	if err != nil {
+		return nil, err
+	}
+
 	if drivers.CertFilePath != "" {
 		volumeMount := corev1.VolumeMount{
 			Name:      utils.TLSCertMountVol,

--- a/pkg/drivers/nfsbackup/nfsbackup.go
+++ b/pkg/drivers/nfsbackup/nfsbackup.go
@@ -306,6 +306,12 @@ func jobForBackupResource(
 		}
 	}
 
+	// Add node affinity to the job spec
+	job, err = utils.AddNodeAffinityToJob(job, jobOption)
+	if err != nil {
+		return nil, err
+	}
+
 	// Add the image secret in job spec only if it is present in the stork deployment.
 	if len(imageRegistrySecret) != 0 {
 		job.Spec.Template.Spec.ImagePullSecrets = utils.ToImagePullSecret(utils.GetImageSecretName(jobOption.RestoreExportName))

--- a/pkg/drivers/nfscsirestore/nfscsirestore.go
+++ b/pkg/drivers/nfscsirestore/nfscsirestore.go
@@ -286,6 +286,13 @@ func jobForRestoreCSISnapshot(
 	if len(imageRegistrySecret) != 0 {
 		job.Spec.Template.Spec.ImagePullSecrets = utils.ToImagePullSecret(utils.GetImageSecretName(jobName))
 	}
+
+	// Add node affinity to the job spec
+	job, err = utils.AddNodeAffinityToJob(job, jobOption)
+	if err != nil {
+		return nil, err
+	}
+
 	if len(jobOption.NfsServer) != 0 {
 		volumeMount := corev1.VolumeMount{
 			Name:      utils.NfsVolumeName,

--- a/pkg/drivers/nfsrestore/nfsrestore.go
+++ b/pkg/drivers/nfsrestore/nfsrestore.go
@@ -327,6 +327,13 @@ func jobForRestoreResource(
 	if err != nil {
 		return nil, err
 	}
+
+	// Add node affinity to the job spec
+	job, err = utils.AddNodeAffinityToJob(job, jobOption)
+	if err != nil {
+		return nil, err
+	}
+
 	// Add the image secret in job spec only if it is present in the stork deployment.
 	if len(imageRegistrySecret) != 0 {
 		job.Spec.Template.Spec.ImagePullSecrets = utils.ToImagePullSecret(utils.GetImageSecretName(jobOption.RestoreExportName))


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: It adds node affinity rule to kopia backup and restore jobs

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PB-7476

**Special notes for your reviewer**:
The user needs to add this label to kdmp-config **PXB_JOB_NODE_AFFINITY_LABEL:kopia-backup**
This label has to be added to the application node pool as well
**Unit Testing**

1.  Add label to node and kdmp config **Node-2**
<img width="1664" alt="Screenshot 2024-08-01 at 10 27 02 AM" src="https://github.com/user-attachments/assets/33f54089-7ce7-40dc-8e8a-8fb6d8365e66">

2.  Assigned label to a different node, other than node on which the mysql-pod is assigned which we be taking the backup of (mysql app with pvc running on **Node 3**)
<img width="1728" alt="mysqlappwithpvcNode" src="https://github.com/user-attachments/assets/01af25e2-1f2f-4a6f-b093-f54cae16da87">

3. Took a backup of default namespace containing mysql app with pvc and noapp-pvc
Job pod created for mysql app with pvc got assigned to Node 3 with no node affinity in it's spec
<img width="1728" alt="livebackuppodwithoutnodeaffinity" src="https://github.com/user-attachments/assets/29ab723c-da4c-4ba6-8f92-d04a591b16b7">

**Updated result**
<img width="968" alt="Screenshot 2024-08-06 at 1 12 08 PM" src="https://github.com/user-attachments/assets/cb0fddc8-5fb6-4fd1-82ca-4211a586a908">


Job pod created for noapp-pvc got assigned to node 2 with node affinity in it's spec
<img width="1728" alt="nonlivebackupwithnodeafffinity" src="https://github.com/user-attachments/assets/c4d62ee6-e10e-4ccb-a5e4-7b995d61a5ff">

**Updated result**
<img width="979" alt="Screenshot 2024-08-06 at 1 09 12 PM" src="https://github.com/user-attachments/assets/ee4334c2-6709-4c2a-b136-50908fbabd8b">

**NFS backup Job Node Affinity**
<img width="1139" alt="Screenshot 2024-08-01 at 11 06 52 AM" src="https://github.com/user-attachments/assets/7aa4077d-45b3-41f3-a39e-cedf2e790346">
**Updated Result**
<img width="962" alt="Screenshot 2024-08-06 at 1 28 07 PM" src="https://github.com/user-attachments/assets/70dce436-2d1b-401c-9890-4999f6064d78">

**NFS Restore Pod**
<img width="1528" alt="Screenshot 2024-07-19 at 11 16 55 AM" src="https://github.com/user-attachments/assets/2ec8f525-5f0c-4122-9861-19e97ff716aa">
**Updated Result**
<img width="968" alt="Screenshot 2024-08-06 at 1 32 30 PM" src="https://github.com/user-attachments/assets/a8ed2395-2223-40d4-b2e5-d72d885c1a91">

**Kopia Restore Pod**
<img width="1508" alt="Screenshot 2024-07-19 at 11 19 30 AM" src="https://github.com/user-attachments/assets/01a035c8-2183-4c2f-88f6-66e817c22fd0">

**Updated result**
noapp-pvc restore
<img width="1354" alt="Screenshot 2024-08-06 at 1 17 32 PM" src="https://github.com/user-attachments/assets/2587588f-8100-43ba-a610-b58bcfe8539c">

mysql-pvc restore
<img width="945" alt="Screenshot 2024-08-06 at 1 17 44 PM" src="https://github.com/user-attachments/assets/17fb30e9-af3d-4175-bb1f-59111f85066b">


csi backup on nfs bl
<img width="1728" alt="Screenshot 2024-08-05 at 5 57 13 PM" src="https://github.com/user-attachments/assets/2fd259ae-3024-4e7e-a756-7020d7b1962d">
<img width="1728" alt="Screenshot 2024-08-05 at 6 01 49 PM" src="https://github.com/user-attachments/assets/c7798d22-4ff0-42c6-bad1-88609e2319ca">

**nfscsirestore**
<img width="1728" alt="Screenshot 2024-08-05 at 6 06 07 PM" src="https://github.com/user-attachments/assets/6a4abb8e-f4ba-4460-ae6b-4c4ad7f23891">
<img width="662" alt="Screenshot 2024-08-05 at 6 09 05 PM" src="https://github.com/user-attachments/assets/bc73b1d1-58c3-4ab8-9179-9dd284276287">
**Updated result**
<img width="1279" alt="Screenshot 2024-08-06 at 1 51 03 PM" src="https://github.com/user-attachments/assets/ab8c85d2-18ff-42f3-a5c6-b3cf35894c03">

<img width="1407" alt="Screenshot 2024-08-06 at 1 51 31 PM" src="https://github.com/user-attachments/assets/fdf05095-c439-4345-85d6-5644974399c9">
<img width="1152" alt="Screenshot 2024-08-06 at 1 52 00 PM" src="https://github.com/user-attachments/assets/9d7af6d8-dcf5-4218-93d4-4a79d02d89c3">

Verified taking backup in psa **environment**
psa environmnet + postgress app with pvc  (backup successful)
psa environment - only pvc (backup failed)
<img width="608" alt="Screenshot 2024-08-06 at 5 59 27 PM" src="https://github.com/user-attachments/assets/1a4e411a-eb20-475b-806e-6cfa5de6ebf1">
<img width="614" alt="Screenshot 2024-08-06 at 6 02 54 PM" src="https://github.com/user-attachments/assets/14d2e811-c300-4b09-90d4-c797ebdff1f3">
**central ns psa environment**
<img width="805" alt="Screenshot 2024-08-06 at 6 03 51 PM" src="https://github.com/user-attachments/assets/8f303c26-7bd3-4d99-af3f-8fc105d07e2b">
