### PR TITLE
pb-7598: Removed default addition of the RunAsGroup in the securityAc…

### DIFF
--- a/pkg/drivers/nfsbackup/nfsbackup.go
+++ b/pkg/drivers/nfsbackup/nfsbackup.go
@@ -281,7 +281,9 @@ func jobForBackupResource(
 	// The Job is intended to backup resources to  NFS backuplocation
 	// and it doesn't need a specific JOB uid/gid since it will be sqaushed at NFS server
 	// hence used a global hardcoded UID/GID.
-	job, err = utils.AddSecurityContextToJob(job, utils.KdmpJobUid, utils.KdmpJobGid)
+	// Not passing the groupId as we do not want to set the RunAsGroup field in the securityContext
+	// This helps us in setting the primaryGroup ID to root for the user ID.
+	job, err = utils.AddSecurityContextToJob(job, utils.KdmpJobUid, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drivers/nfsrestore/nfsrestore.go
+++ b/pkg/drivers/nfsrestore/nfsrestore.go
@@ -321,7 +321,9 @@ func jobForRestoreResource(
 			},
 		},
 	}
-	job, err = utils.AddSecurityContextToJob(job, utils.KdmpJobUid, utils.KdmpJobGid)
+	// Not passing the groupId as we do not want to set the RunAsGroup field in the securityContext
+	// This helps us in setting the primaryGroup ID to root for the user ID.
+	job, err = utils.AddSecurityContextToJob(job, utils.KdmpJobUid, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drivers/utils/utils.go
+++ b/pkg/drivers/utils/utils.go
@@ -1019,7 +1019,10 @@ func AddSecurityContextToJob(job *batchv1.Job, podUserId, podGroupId string) (*b
 	// if the namespace is OCP, then overwrite the UID and GID from the namespace annotation
 	if isOcp {
 		podUserId = ocpUid
-		podGroupId = ocpGid
+		// In the case of the OCP, we will not update the groupId.
+		if podGroupId != "" {
+			podGroupId = ocpGid
+		}
 	}
 
 	if podUserId != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-7598: Removed default addition of the RunAsGroup in the securityAccount.
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-7598

**Special notes for your reviewer**:
Testing:
Tested the backup/restore with OCP setup of application that had RDB volume with offload option, which was failing previous with permission denied error.

![Screenshot 2024-07-18 at 3 31 42 PM](https://github.com/user-attachments/assets/b52c4fb3-f731-4210-967a-04d862851b58)
![Screenshot 2024-07-18 at 3 31 33 PM](https://github.com/user-attachments/assets/b6b4829e-29f4-4591-9da3-b66bf2a470da)


