### PR TITLE
PB-7859: Add node affinity for kdmp live backup job pods with ROX or RWX access modes

### DIFF
--- a/pkg/drivers/utils/utils.go
+++ b/pkg/drivers/utils/utils.go
@@ -1168,3 +1168,13 @@ func AddNodeAffinityToJob(job *batchv1.Job, jobOption drivers.JobOpts) (*batchv1
 	}
 	return job, nil
 }
+
+// GetAccessModeFromPvc gets the access modes of the pvc
+func GetAccessModeFromPvc(srcPvcName, srcPvcNameSpace string) ([]corev1.PersistentVolumeAccessMode, error) {
+	srcPvc, err := core.Instance().GetPersistentVolumeClaim(srcPvcName, srcPvcNameSpace)
+	if err != nil {
+		return nil, err
+	}
+	accessModes := srcPvc.Status.AccessModes
+	return accessModes, nil
+}


### PR DESCRIPTION
Add node affinity for kdmp live backup job pods with ROX or RWX access modes

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  To add node affinity for kdmp live backup job pods with ROX or RWX access modes

**Which issue(s) this PR fixes** (optional)
Closes # [PB-7859](https://purestorage.atlassian.net/browse/PB-7859)

**Special notes for your reviewer**:

**Node affinity set on node**
<img width="1556" alt="Screenshot 2024-08-16 at 2 23 22 AM" src="https://github.com/user-attachments/assets/d98e8efb-ea54-4843-b1ac-29e43ec7e3cd">

**RWO access mode, no node affinity set**
<img width="1172" alt="Screenshot 2024-08-22 at 11 33 53 AM" src="https://github.com/user-attachments/assets/3f41234e-267b-48ed-8262-50c8ec244955">

**RWO, RWX access mode, no node affinity set**
<img width="1247" alt="Screenshot 2024-08-22 at 12 32 04 PM" src="https://github.com/user-attachments/assets/3c1e4cb5-5a47-473e-ae48-c70adb36b860">

**RWX access mode, node affinity added**
<img width="1318" alt="Screenshot 2024-08-22 at 1 01 49 PM" src="https://github.com/user-attachments/assets/b50ee32b-c7d7-4079-b4fa-f26b39b1d3aa">

**ROX access mode, node affinity added**
<img width="1464" alt="Screenshot 2024-08-22 at 2 06 31 PM" src="https://github.com/user-attachments/assets/f52e2ae7-ff25-4948-bcd2-7044ca5cdad5">

**RWX, ROX, RWO access modes, no node affinity set**
<img width="1273" alt="Screenshot 2024-08-22 at 4 28 19 PM" src="https://github.com/user-attachments/assets/ac7e99a9-bc50-4226-a5c0-771042c75df3">

**RWX, ROX access modes, node affinity set**
<img width="1228" alt="Screenshot 2024-08-22 at 4 53 15 PM" src="https://github.com/user-attachments/assets/21bcc3aa-2e1e-42fb-a8f0-2796f2029af5">

**RWX, RWO access mode, node affinity not set**
<img width="1224" alt="Screenshot 2024-08-22 at 5 15 53 PM" src="https://github.com/user-attachments/assets/be466ef6-2156-402a-86f2-2fbabfa99cd2">


[PB-7859]: https://purestorage.atlassian.net/browse/PB-7859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ