### PR TITLE
PB-8293 : Implement a new log writer which flushes the logs in every 30 seconds (for real time logs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ staticcheck:
 errcheck:
 	docker run --rm -v $(shell pwd):/go/src/github.com/portworx/kdmp $(DOCK_BUILD_CNT) \
 		/bin/bash -c "cd /go/src/github.com/portworx/kdmp; \
-	GO111MODULE=off go get -u github.com/kisielk/errcheck; \
+	go install github.com/kisielk/errcheck@v1.7.0; \
 	git config --global --add safe.directory /go/src/github.com/portworx/kdmp; \
 	errcheck -ignoregenerated -ignorepkg fmt -verbose -blank $(PKGS); \
 	errcheck -ignoregenerated -ignorepkg fmt -verbose -blank -tags unittest $(PKGS)"


### PR DESCRIPTION
…30 seconds (for real time logs)

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Currently the output of kopia backup/restore command is flushed in to the pod logs only after the cmd execution , so the user is not aware of the progress This PR Implements a new log writer which flushes the logs in every 30 seconds (for real time logs)

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PB-8293

**Special notes for your reviewer**:

Output for backup 

![Screenshot from 2024-09-19 10-28-56](https://github.com/user-attachments/assets/1be73719-19eb-461b-86cc-b12f1bb25154)

Attached additional testing details with logs in the ticket https://purestorage.atlassian.net/browse/PB-8293

