### PR TITLE
PB-8347: Fix KDMP Backup Failure in-case KDMP job removed post VB CR is updated with SnapshotID

### DIFF
--- a/pkg/executor/kopia/kopiabackup.go
+++ b/pkg/executor/kopia/kopiabackup.go
@@ -89,7 +89,7 @@ func runBackup(sourcePath string) error {
 		repo.Name = repoName
 	}
 	if volumeBackupName != "" {
-		if err := executor.CreateVolumeBackup(
+		if isSnapshotIDExists, err := executor.CreateVolumeBackup(
 			volumeBackupName,
 			bkpNamespace,
 			repoName,
@@ -98,6 +98,8 @@ func runBackup(sourcePath string) error {
 		); err != nil {
 			logrus.Errorf("%s: %v", fn, err)
 			return err
+		} else if isSnapshotIDExists {
+			return nil
 		}
 	}
 	if rErr != nil {

--- a/pkg/executor/restic/resticbackup.go
+++ b/pkg/executor/restic/resticbackup.go
@@ -57,7 +57,7 @@ func runBackup(sourcePath string) error {
 	}
 
 	if volumeBackupName != "" {
-		if err = executor.CreateVolumeBackup(
+		if _, err = executor.CreateVolumeBackup(
 			volumeBackupName,
 			namespace,
 			repo.Name,


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
	- Update CreateVolumeBackup to return a boolean based upon the snapshotID
	- Update KopiaBackup runBackup to exit successfully in case the VB CR already holds the snapshotID
	
**Which issue(s) this PR fixes** (optional)
Closes #PB-8347

**Special notes for your reviewer**:
PFA of Testing Screenshots
![Screenshot from 2024-10-17 20-15-27](https://github.com/user-attachments/assets/38c45beb-054a-4304-b8a1-caa99c7490fb)
![Screenshot from 2024-10-17 20-15-16](https://github.com/user-attachments/assets/acdb6d97-8504-42a1-a9c2-80dbdf134204)
![Screenshot from 2024-10-17 20-14-55](https://github.com/user-attachments/assets/d8924859-84a5-4f8b-bc1c-6291156e346a)
![Screenshot from 2024-10-17 20-14-39](https://github.com/user-attachments/assets/d13f8d00-4c7a-4ac4-8b30-7244dc01d3ba)
