### PR TITLE
Adding support for anyuid annotation in case of OCP

### DIFF
--- a/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/pkg/drivers/kopiarestore/kopiarestore.go
@@ -191,6 +191,12 @@ func jobFor(
 		return nil, err
 	}
 
+	if err := utils.SetupRoleBindingForSCC(jobName, jobOption.Namespace, jobOption.DestinationPVCName); err != nil {
+		errMsg := fmt.Sprintf("error creating role binding %s/%s: %v", jobOption.Namespace, jobName, err)
+		logrus.Errorf(errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
 	cmd := strings.Join([]string{
 		"/kopiaexecutor",
 		"restore",
@@ -297,7 +303,7 @@ func jobFor(
 	}
 	// Add security Context only if the PSA is enabled.
 	if jobOption.PodUserId != "" || jobOption.PodGroupId != "" {
-		job, err = utils.AddSecurityContextToJob(job, jobOption.PodUserId, jobOption.PodGroupId)
+		job, err = utils.AddSecurityContextToJob(job, jobOption.PodUserId, jobOption.PodGroupId, jobOption.DestinationPVCName, jobOption.Namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/drivers/nfsbackup/nfsbackup.go
+++ b/pkg/drivers/nfsbackup/nfsbackup.go
@@ -146,6 +146,12 @@ func buildJob(
 		return nil, fmt.Errorf(errMsg)
 	}
 
+	if err := utils.SetupRoleBindingForSCC(jobOptions.RestoreExportName, jobOptions.Namespace, jobOptions.SourcePVCName); err != nil {
+		errMsg := fmt.Sprintf("error creating role binding %s/%s: %v", jobOptions.Namespace, jobOptions.RestoreExportName, err)
+		logrus.Errorf("%s: %v", funct, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
 	resources, err := utils.NFSResourceRequirements(jobOptions.JobConfigMap, jobOptions.JobConfigMapNs)
 	if err != nil {
 		return nil, err
@@ -300,7 +306,7 @@ func jobForBackupResource(
 	// Not passing the groupId as we do not want to set the RunAsGroup field in the securityContext
 	// This helps us in setting the primaryGroup ID to root for the user ID.
 	if uid != "" {
-		job, err = utils.AddSecurityContextToJob(job, uid, "")
+		job, err = utils.AddSecurityContextToJob(job, uid, "", jobOption.SourcePVCName, jobOption.SourcePVCNamespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/drivers/nfscsirestore/nfscsirestore.go
+++ b/pkg/drivers/nfscsirestore/nfscsirestore.go
@@ -147,6 +147,12 @@ func buildJob(
 		return nil, fmt.Errorf(errMsg)
 	}
 
+	if err := utils.SetupRoleBindingForSCC(jobName, jobOptions.Namespace, jobOptions.DestinationPVCName); err != nil {
+		errMsg := fmt.Sprintf("error creating role binding %s/%s: %v", jobOptions.Namespace, jobName, err)
+		logrus.Errorf("%s: %v", funct, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
 	resources, err := utils.NFSResourceRequirements(jobOptions.JobConfigMap, jobOptions.JobConfigMapNs)
 	if err != nil {
 		return nil, err
@@ -277,7 +283,7 @@ func jobForRestoreCSISnapshot(
 	}
 	// Add security Context only if the PSA is enabled.
 	if jobOption.PodUserId != "" || jobOption.PodGroupId != "" {
-		job, err = utils.AddSecurityContextToJob(job, jobOption.PodUserId, jobOption.PodGroupId)
+		job, err = utils.AddSecurityContextToJob(job, jobOption.PodUserId, jobOption.PodGroupId, jobOption.DestinationPVCName, jobOption.Namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/drivers/nfsrestore/nfsrestore.go
+++ b/pkg/drivers/nfsrestore/nfsrestore.go
@@ -147,6 +147,12 @@ func buildJob(
 		return nil, fmt.Errorf(errMsg)
 	}
 
+	if err := utils.SetupRoleBindingForSCC(jobOptions.RestoreExportName, jobOptions.Namespace, jobOptions.DestinationPVCName); err != nil {
+		errMsg := fmt.Sprintf("error creating role binding %s/%s: %v", jobOptions.Namespace, jobOptions.RestoreExportName, err)
+		logrus.Errorf("%s: %v", funct, errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
 	resources, err := utils.NFSResourceRequirements(jobOptions.JobConfigMap, jobOptions.JobConfigMapNs)
 	if err != nil {
 		return nil, err
@@ -323,7 +329,7 @@ func jobForRestoreResource(
 	}
 	// Not passing the groupId as we do not want to set the RunAsGroup field in the securityContext
 	// This helps us in setting the primaryGroup ID to root for the user ID.
-	job, err = utils.AddSecurityContextToJob(job, utils.KdmpJobUid, "")
+	job, err = utils.AddSecurityContextToJob(job, utils.KdmpJobUid, "", jobOption.DestinationPVCName, jobOption.Namespace)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR is to fix the IBM customer issue which is described in this ticket https://purestorage.atlassian.net/browse/PB-8586 

Where we are trying to add anyuid annotations to any required provisioners on OCP cluster

**Which issue(s) this PR fixes** (optional)
Closes #
https://purestorage.atlassian.net/browse/PB-8630

**Special notes for your reviewer**:

- Took kdmp backup of the DB2 application running on IBM ROKS cluster with storage provisioner  ibm-vpc-file 
Backup create successfully along with which the anyuid annotation was added to kdmp jobs running on the application cluster
![Screenshot 2024-11-14 at 3 39 23 PM](https://github.com/user-attachments/assets/8e97bfd6-90cd-4705-abde-a33cb42eb475)
![Screenshot 2024-11-15 at 11 57 54 AM](https://github.com/user-attachments/assets/1b18a292-fdc2-4440-891b-b9fa5c4e38f9)

- Restore the KDMP backup of DB2 application and verified kdmp job pods having anyuid annotations
<img width="534" alt="Screenshot 2024-11-17 at 6 58 12 PM" src="https://github.com/user-attachments/assets/42669815-8f23-4b0f-b49e-67a7c80142a1">
<img width="680" alt="Screenshot 2024-11-17 at 6 50 16 PM" src="https://github.com/user-attachments/assets/c0e93422-34d6-4f0e-965b-0354dabde890">

- Take kdmp backup of ibm block storage provisioner without setting PROVISIONERS_TO_USE_ANYUID in kdmp-config config-map. And verify backup created successfully without adding anyuid annotations to kdmp job pods
<img width="534" alt="Screenshot 2024-11-17 at 8 13 21 PM" src="https://github.com/user-attachments/assets/8ba062c1-1faa-4192-8f1b-8ead1fad2f97">

- Take csi backup of the ibm block storage provisioner
![Screenshot 2024-11-18 at 10 43 21 AM](https://github.com/user-attachments/assets/401e00d5-f0a7-46a2-b69d-5afde7d7b2a2)

